### PR TITLE
feat: ecosystem-aware test/build commands

### DIFF
--- a/packages/core/src/ecosystem/ecosystem.ts
+++ b/packages/core/src/ecosystem/ecosystem.ts
@@ -13,8 +13,8 @@ export abstract class Ecosystem {
   abstract registryClasses(): (typeof PackageRegistry)[];
   abstract writeVersion(newVersion: string): Promise<void>;
   abstract manifestFiles(): string[];
-  abstract defaultTestCommand(): Promise<string> | string;
-  abstract defaultBuildCommand(): Promise<string> | string;
+  abstract defaultTestCommand(scriptName?: string): Promise<string> | string;
+  abstract defaultBuildCommand(scriptName?: string): Promise<string> | string;
   abstract supportedRegistries(): RegistryType[];
   abstract createDescriptor(): Promise<EcosystemDescriptor>;
 

--- a/packages/core/src/ecosystem/js.ts
+++ b/packages/core/src/ecosystem/js.ts
@@ -68,14 +68,14 @@ export class JsEcosystem extends Ecosystem {
     return ["package.json"];
   }
 
-  async defaultTestCommand(): Promise<string> {
+  async defaultTestCommand(scriptName?: string): Promise<string> {
     const pm = await getPackageManager();
-    return `${pm} run test`;
+    return `${pm} run ${scriptName ?? "test"}`;
   }
 
-  async defaultBuildCommand(): Promise<string> {
+  async defaultBuildCommand(scriptName?: string): Promise<string> {
     const pm = await getPackageManager();
-    return `${pm} run build`;
+    return `${pm} run ${scriptName ?? "build"}`;
   }
 
   supportedRegistries(): RegistryType[] {

--- a/packages/core/src/ecosystem/rust.ts
+++ b/packages/core/src/ecosystem/rust.ts
@@ -109,11 +109,11 @@ export class RustEcosystem extends Ecosystem {
     return ["Cargo.toml"];
   }
 
-  defaultTestCommand(): string {
+  defaultTestCommand(_scriptName?: string): string {
     return "cargo test";
   }
 
-  defaultBuildCommand(): string {
+  defaultBuildCommand(_scriptName?: string): string {
     return "cargo build --release";
   }
 

--- a/packages/core/src/plugin/types.ts
+++ b/packages/core/src/plugin/types.ts
@@ -114,7 +114,6 @@ export interface PluginRegistryDefinition {
   tokenConfig: TokenEntry;
   unpublishLabel: string;
   requiresEarlyAuth: boolean;
-  needsPackageScripts: boolean;
   concurrentPublish: boolean;
   additionalEnvVars?: (token: string) => Record<string, string>;
   validateToken?: (token: string) => Promise<boolean>;

--- a/packages/core/src/registry/catalog.ts
+++ b/packages/core/src/registry/catalog.ts
@@ -29,7 +29,6 @@ export interface RegistryDescriptor {
   ecosystem: EcosystemKey;
   label: string;
   tokenConfig: TokenEntry;
-  needsPackageScripts: boolean;
   additionalEnvVars?: (token: string) => Record<string, string>;
   validateToken?: (token: string) => Promise<boolean>;
   resolveTokenUrl?: (baseUrl: string) => Promise<string>;
@@ -128,7 +127,6 @@ registryCatalog.register({
       "https://www.npmjs.com/settings/~/tokens/granular-access-tokens/new",
     tokenUrlLabel: "npmjs.com",
   },
-  needsPackageScripts: true,
   additionalEnvVars: (token) => ({
     "npm_config_//registry.npmjs.org/:_authToken": token,
   }),
@@ -184,7 +182,6 @@ registryCatalog.register({
     tokenUrl: "https://jsr.io/account/tokens/create",
     tokenUrlLabel: "jsr.io",
   },
-  needsPackageScripts: false,
   validateToken: async (token) => {
     const res = await fetch("https://jsr.io/api/user", {
       headers: { Authorization: `Bearer ${token}` },
@@ -231,7 +228,6 @@ registryCatalog.register({
     tokenUrl: "https://crates.io/settings/tokens/new",
     tokenUrlLabel: "crates.io",
   },
-  needsPackageScripts: false,
   validateToken: async (token) => {
     return token.trim().length >= 32;
   },
@@ -285,7 +281,6 @@ export function registerPrivateRegistry(
       tokenUrl: config.url,
       tokenUrlLabel: key,
     },
-    needsPackageScripts: false,
     concurrentPublish: true,
     unpublishLabel: "Unpublish",
     requiresEarlyAuth: false,

--- a/packages/core/src/registry/crates.ts
+++ b/packages/core/src/registry/crates.ts
@@ -227,7 +227,6 @@ export class CratesPackageRegistry extends PackageRegistry {
 
   getRequirements(): RegistryRequirements {
     return {
-      needsPackageScripts: false,
       requiredManifest: "Cargo.toml",
     };
   }

--- a/packages/core/src/registry/jsr.ts
+++ b/packages/core/src/registry/jsr.ts
@@ -277,7 +277,6 @@ export class JsrPackageRegistry extends PackageRegistry {
 
   getRequirements(): RegistryRequirements {
     return {
-      needsPackageScripts: false,
       requiredManifest: "jsr.json or deno.json",
     };
   }

--- a/packages/core/src/registry/npm.ts
+++ b/packages/core/src/registry/npm.ts
@@ -470,7 +470,6 @@ export class NpmPackageRegistry extends PackageRegistry {
 
   getRequirements(): RegistryRequirements {
     return {
-      needsPackageScripts: true,
       requiredManifest: "package.json",
     };
   }

--- a/packages/core/src/registry/package-registry.ts
+++ b/packages/core/src/registry/package-registry.ts
@@ -4,7 +4,6 @@ import type { ManifestReader } from "../manifest/manifest-reader.js";
 import type { RegistryType } from "../types/options.js";
 
 export interface RegistryRequirements {
-  needsPackageScripts: boolean;
   requiredManifest: string;
 }
 

--- a/packages/core/src/tasks/phases/test-build.ts
+++ b/packages/core/src/tasks/phases/test-build.ts
@@ -12,7 +12,7 @@ import {
 function collectUniqueEcosystems(ctx: PubmContext): string[] {
   const seen = new Set<string>();
   for (const pkg of ctx.config.packages) {
-    if (pkg.ecosystem) seen.add(pkg.ecosystem);
+    seen.add(pkg.ecosystem ?? "js");
   }
   return [...seen];
 }
@@ -53,11 +53,15 @@ export function createTestTask(
       await ctx.runtime.pluginRunner.runHook("beforeTest", ctx);
 
       const ecosystems = collectUniqueEcosystems(ctx);
+      const executedCommands: string[] = [];
       for (const key of ecosystems) {
         const descriptor = ecosystemCatalog.get(key);
         if (!descriptor) continue;
         const instance = new descriptor.ecosystemClass(ctx.cwd);
-        const command = await instance.defaultTestCommand();
+        const command = await instance.defaultTestCommand(
+          ctx.options.testScript,
+        );
+        executedCommands.push(command);
         task.title = t("task.test.titleWithCommand", { command });
 
         try {
@@ -76,7 +80,7 @@ export function createTestTask(
       task.output = t("task.test.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterTest", ctx);
       task.output = t("task.test.completed", {
-        command: ecosystems.join(", "),
+        command: executedCommands.join(", "),
       });
     },
   };
@@ -94,11 +98,15 @@ export function createBuildTask(
       await ctx.runtime.pluginRunner.runHook("beforeBuild", ctx);
 
       const ecosystems = collectUniqueEcosystems(ctx);
+      const executedCommands: string[] = [];
       for (const key of ecosystems) {
         const descriptor = ecosystemCatalog.get(key);
         if (!descriptor) continue;
         const instance = new descriptor.ecosystemClass(ctx.cwd);
-        const command = await instance.defaultBuildCommand();
+        const command = await instance.defaultBuildCommand(
+          ctx.options.buildScript,
+        );
+        executedCommands.push(command);
         task.title = t("task.build.titleWithCommand", { command });
 
         try {
@@ -117,7 +125,7 @@ export function createBuildTask(
       task.output = t("task.build.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterBuild", ctx);
       task.output = t("task.build.completed", {
-        command: ecosystems.join(", "),
+        command: executedCommands.join(", "),
       });
     },
   };

--- a/packages/core/src/tasks/phases/test-build.ts
+++ b/packages/core/src/tasks/phases/test-build.ts
@@ -1,13 +1,45 @@
 import type { ListrTask } from "listr2";
 import type { PubmContext } from "../../context.js";
+import { ecosystemCatalog } from "../../ecosystem/catalog.js";
 import { AbstractError } from "../../error.js";
 import { t } from "../../i18n/index.js";
 import { exec } from "../../utils/exec.js";
-import { getPackageManager } from "../../utils/package-manager.js";
 import {
   createLiveCommandOutput,
   shouldRenderLiveCommandOutput,
 } from "../runner-utils/output-formatting.js";
+
+function collectUniqueEcosystems(ctx: PubmContext): string[] {
+  const seen = new Set<string>();
+  for (const pkg of ctx.config.packages) {
+    if (pkg.ecosystem) seen.add(pkg.ecosystem);
+  }
+  return [...seen];
+}
+
+async function execEcosystemCommand(
+  ctx: PubmContext,
+  // biome-ignore lint/suspicious/noExplicitAny: listr2 TaskWrapper type is complex
+  task: any,
+  command: string,
+): Promise<void> {
+  const parts = command.split(/\s+/);
+  const [cmd, ...args] = parts;
+  const liveOutput = shouldRenderLiveCommandOutput(ctx)
+    ? createLiveCommandOutput(task, command)
+    : undefined;
+  task.output = `Executing \`${command}\``;
+
+  try {
+    await exec(cmd, args, {
+      onStdout: liveOutput?.onStdout,
+      onStderr: liveOutput?.onStderr,
+      throwOnError: true,
+    });
+  } finally {
+    liveOutput?.finish();
+  }
+}
 
 export function createTestTask(
   hasPrepare: boolean,
@@ -19,34 +51,33 @@ export function createTestTask(
     task: async (ctx, task): Promise<void> => {
       task.output = t("task.test.runningBeforeHooks");
       await ctx.runtime.pluginRunner.runHook("beforeTest", ctx);
-      const packageManager = await getPackageManager();
-      const command = `${packageManager} run ${ctx.options.testScript}`;
-      task.title = t("task.test.titleWithCommand", { command });
-      const liveOutput = shouldRenderLiveCommandOutput(ctx)
-        ? createLiveCommandOutput(task, command)
-        : undefined;
-      task.output = `Executing \`${command}\``;
 
-      try {
-        await exec(packageManager, ["run", ctx.options.testScript], {
-          onStdout: liveOutput?.onStdout,
-          onStderr: liveOutput?.onStderr,
-          throwOnError: true,
-        });
-      } catch (error) {
-        liveOutput?.finish();
-        throw new AbstractError(
-          t("error.test.failedWithHint", {
-            script: ctx.options.testScript,
-            command,
-          }),
-          { cause: error },
-        );
+      const ecosystems = collectUniqueEcosystems(ctx);
+      for (const key of ecosystems) {
+        const descriptor = ecosystemCatalog.get(key);
+        if (!descriptor) continue;
+        const instance = new descriptor.ecosystemClass(ctx.cwd);
+        const command = await instance.defaultTestCommand();
+        task.title = t("task.test.titleWithCommand", { command });
+
+        try {
+          await execEcosystemCommand(ctx, task, command);
+        } catch (error) {
+          throw new AbstractError(
+            t("error.test.failedWithHint", {
+              script: command,
+              command,
+            }),
+            { cause: error },
+          );
+        }
       }
-      liveOutput?.finish();
+
       task.output = t("task.test.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterTest", ctx);
-      task.output = t("task.test.completed", { command });
+      task.output = t("task.test.completed", {
+        command: ecosystems.join(", "),
+      });
     },
   };
 }
@@ -61,34 +92,33 @@ export function createBuildTask(
     task: async (ctx, task): Promise<void> => {
       task.output = t("task.build.runningBeforeHooks");
       await ctx.runtime.pluginRunner.runHook("beforeBuild", ctx);
-      const packageManager = await getPackageManager();
-      const command = `${packageManager} run ${ctx.options.buildScript}`;
-      task.title = t("task.build.titleWithCommand", { command });
-      const liveOutput = shouldRenderLiveCommandOutput(ctx)
-        ? createLiveCommandOutput(task, command)
-        : undefined;
-      task.output = `Executing \`${command}\``;
 
-      try {
-        await exec(packageManager, ["run", ctx.options.buildScript], {
-          onStdout: liveOutput?.onStdout,
-          onStderr: liveOutput?.onStderr,
-          throwOnError: true,
-        });
-      } catch (error) {
-        liveOutput?.finish();
-        throw new AbstractError(
-          t("error.build.failedWithHint", {
-            script: ctx.options.buildScript,
-            command,
-          }),
-          { cause: error },
-        );
+      const ecosystems = collectUniqueEcosystems(ctx);
+      for (const key of ecosystems) {
+        const descriptor = ecosystemCatalog.get(key);
+        if (!descriptor) continue;
+        const instance = new descriptor.ecosystemClass(ctx.cwd);
+        const command = await instance.defaultBuildCommand();
+        task.title = t("task.build.titleWithCommand", { command });
+
+        try {
+          await execEcosystemCommand(ctx, task, command);
+        } catch (error) {
+          throw new AbstractError(
+            t("error.build.failedWithHint", {
+              script: command,
+              command,
+            }),
+            { cause: error },
+          );
+        }
       }
-      liveOutput?.finish();
+
       task.output = t("task.build.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterBuild", ctx);
-      task.output = t("task.build.completed", { command });
+      task.output = t("task.build.completed", {
+        command: ecosystems.join(", "),
+      });
     },
   };
 }

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -11,18 +11,11 @@ import { registryCatalog } from "../registry/catalog.js";
 import { getConnector } from "../registry/index.js";
 import { validateEngineVersion } from "../utils/engine-version.js";
 import { createCiListrOptions, createListr } from "../utils/listr.js";
-import { collectRegistries } from "../utils/registries.js";
 import {
   collectEcosystemRegistryGroups,
   ecosystemLabel,
   registryLabel,
 } from "./grouping.js";
-
-function needsPackageScripts(registries: string[]): boolean {
-  return registries.some(
-    (r) => registryCatalog.get(r)?.needsPackageScripts ?? true,
-  );
-}
 
 class RequiredConditionCheckError extends AbstractError {
   name = t("error.conditions.name");
@@ -110,7 +103,8 @@ export const requiredConditionsCheckTask = (
           },
           {
             title: t("task.conditions.checkScripts"),
-            skip: (ctx) => !needsPackageScripts(collectRegistries(ctx.config)),
+            skip: (ctx) =>
+              !ctx.config.packages.some((pkg) => pkg.ecosystem === "js"),
             task: async (ctx): Promise<void> => {
               const raw = await readFile(
                 join(ctx.cwd, "package.json"),

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -104,7 +104,9 @@ export const requiredConditionsCheckTask = (
           {
             title: t("task.conditions.checkScripts"),
             skip: (ctx) =>
-              !ctx.config.packages.some((pkg) => pkg.ecosystem === "js"),
+              !ctx.config.packages.some(
+                (pkg) => (pkg.ecosystem ?? "js") === "js",
+              ),
             task: async (ctx): Promise<void> => {
               const raw = await readFile(
                 join(ctx.cwd, "package.json"),

--- a/packages/core/src/utils/secure-store.ts
+++ b/packages/core/src/utils/secure-store.ts
@@ -1,14 +1,19 @@
-// import { createRequire } from "node:module";
-import Keyring from "@napi-rs/keyring";
 import { Db } from "./db.js";
 
-// const require = createRequire(import.meta.url);
+type KeyringEntry = {
+  getPassword(): string | null;
+  setPassword(value: string): void;
+  deletePassword(): void;
+};
 
-// let Keyring: typeof import("@napi-rs/keyring") | null = null;
+// biome-ignore lint/suspicious/noExplicitAny: lazy-loaded optional native module
+let keyringModule: any;
 
-// try {
-//   Keyring = require("@napi-rs/keyring");
-// } catch {}
+try {
+  keyringModule = await import("@napi-rs/keyring");
+} catch {
+  keyringModule = null;
+}
 
 const KEYRING_SERVICE = "pubm";
 
@@ -24,10 +29,11 @@ export class SecureStore {
     return this.db;
   }
 
-  private getKeyringEntry(field: string): Keyring.Entry | null {
+  private getKeyringEntry(field: string): KeyringEntry | null {
     if (!usesKeyring(field)) return null;
 
-    const Entry = Keyring?.Entry;
+    const mod = keyringModule?.default ?? keyringModule;
+    const Entry = mod?.Entry;
     if (!Entry) return null;
 
     try {

--- a/packages/core/src/utils/secure-store.ts
+++ b/packages/core/src/utils/secure-store.ts
@@ -1,19 +1,5 @@
+import Keyring from "@napi-rs/keyring";
 import { Db } from "./db.js";
-
-type KeyringEntry = {
-  getPassword(): string | null;
-  setPassword(value: string): void;
-  deletePassword(): void;
-};
-
-// biome-ignore lint/suspicious/noExplicitAny: lazy-loaded optional native module
-let keyringModule: any;
-
-try {
-  keyringModule = await import("@napi-rs/keyring");
-} catch {
-  keyringModule = null;
-}
 
 const KEYRING_SERVICE = "pubm";
 
@@ -29,11 +15,10 @@ export class SecureStore {
     return this.db;
   }
 
-  private getKeyringEntry(field: string): KeyringEntry | null {
+  private getKeyringEntry(field: string): Keyring.Entry | null {
     if (!usesKeyring(field)) return null;
 
-    const mod = keyringModule?.default ?? keyringModule;
-    const Entry = mod?.Entry;
+    const Entry = Keyring?.Entry;
     if (!Entry) return null;
 
     try {

--- a/packages/core/tests/unit/registry/catalog.test.ts
+++ b/packages/core/tests/unit/registry/catalog.test.ts
@@ -32,7 +32,6 @@ function createDescriptor(
       tokenUrl: "https://example.com",
       tokenUrlLabel: "example.com",
     },
-    needsPackageScripts: false,
     concurrentPublish: true,
     unpublishLabel: "Unpublish",
     requiresEarlyAuth: false,
@@ -127,7 +126,6 @@ describe("default registrations", () => {
     expect(npm).toBeDefined();
     expect(npm!.ecosystem).toBe("js");
     expect(npm!.label).toBe("npm");
-    expect(npm!.needsPackageScripts).toBe(true);
     expect(npm!.tokenConfig.envVar).toBe("NODE_AUTH_TOKEN");
   });
 
@@ -135,7 +133,6 @@ describe("default registrations", () => {
     const jsr = registryCatalog.get("jsr");
     expect(jsr).toBeDefined();
     expect(jsr!.ecosystem).toBe("js");
-    expect(jsr!.needsPackageScripts).toBe(false);
     expect(jsr!.tokenConfig.envVar).toBe("JSR_TOKEN");
   });
 

--- a/packages/core/tests/unit/registry/crates.test.ts
+++ b/packages/core/tests/unit/registry/crates.test.ts
@@ -105,10 +105,9 @@ describe("CratesPackageRegistry", () => {
   });
 
   describe("getRequirements", () => {
-    it("returns needsPackageScripts false and requiredManifest Cargo.toml", () => {
+    it("returns requiredManifest Cargo.toml", () => {
       const requirements = registry.getRequirements();
       expect(requirements).toEqual({
-        needsPackageScripts: false,
         requiredManifest: "Cargo.toml",
       });
     });

--- a/packages/core/tests/unit/registry/jsr.test.ts
+++ b/packages/core/tests/unit/registry/jsr.test.ts
@@ -477,11 +477,10 @@ describe("JsrPackageRegistry", () => {
 });
 
 describe("getRequirements", () => {
-  it("returns needsPackageScripts false and requiredManifest jsr.json or deno.json", () => {
+  it("returns requiredManifest jsr.json or deno.json", () => {
     const registry = new JsrPackageRegistry("@scope/my-package", FIXTURE_PATH);
     const requirements = registry.getRequirements();
     expect(requirements).toEqual({
-      needsPackageScripts: false,
       requiredManifest: "jsr.json or deno.json",
     });
   });

--- a/packages/core/tests/unit/registry/npm.test.ts
+++ b/packages/core/tests/unit/registry/npm.test.ts
@@ -663,11 +663,10 @@ describe("NpmPackageRegistry", () => {
 });
 
 describe("getRequirements", () => {
-  it("returns needsPackageScripts true and requiredManifest package.json", () => {
+  it("returns requiredManifest package.json", () => {
     const registry = new NpmPackageRegistry("my-package", FIXTURE_PATH);
     const requirements = registry.getRequirements();
     expect(requirements).toEqual({
-      needsPackageScripts: true,
       requiredManifest: "package.json",
     });
   });

--- a/packages/core/tests/unit/tasks/required-conditions-check.test.ts
+++ b/packages/core/tests/unit/tasks/required-conditions-check.test.ts
@@ -43,7 +43,7 @@ function createCtx(
 ): PubmContext {
   return makeTestContext({
     config: {
-      packages: [{ path: ".", registries: ["npm"] }],
+      packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
       ...overrides.config,
     },
     options: overrides.options,
@@ -64,7 +64,6 @@ function makeNpmDescriptor() {
     key: "npm",
     ecosystem: "js",
     label: "npm",
-    needsPackageScripts: true,
     factory: vi.fn(),
   };
 }
@@ -74,7 +73,6 @@ function makeJsrDescriptor() {
     key: "jsr",
     ecosystem: "js",
     label: "jsr",
-    needsPackageScripts: false,
     factory: vi.fn(),
   };
 }
@@ -84,7 +82,6 @@ function makeCratesDescriptor() {
     key: "crates",
     ecosystem: "rust",
     label: "crates.io",
-    needsPackageScripts: false,
     factory: vi.fn(),
   };
 }
@@ -332,33 +329,27 @@ describe("requiredConditionsCheckTask", () => {
   });
 
   describe("Subtask 2: Scripts existence check", () => {
-    it("skips when all registries have needsPackageScripts false (e.g., jsr only)", async () => {
+    it("skips when no JS ecosystem packages exist (e.g., crates only)", async () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: { packages: [{ path: ".", registries: ["jsr"] }] },
+        config: {
+          packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
+        },
       });
 
       expect(scriptsTask.skip(ctx)).toBe(true);
     });
 
-    it("defaults to true (does not skip) when registryCatalog.get returns undefined for unknown registry", async () => {
+    it("does not skip when JS ecosystem packages exist", async () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: { packages: [{ path: ".", registries: ["unknown-registry"] }] },
-      });
-
-      // registryCatalog.get("unknown-registry") returns undefined
-      // needsPackageScripts defaults to true via ?? true
-      expect(scriptsTask.skip(ctx)).toBe(false);
-    });
-
-    it("does not skip when any registry has needsPackageScripts true", async () => {
-      const subtasks = await getSubtasks();
-      const scriptsTask = subtasks[1];
-      const ctx = createCtx({
-        config: { packages: [{ path: ".", registries: ["npm", "jsr"] }] },
+        config: {
+          packages: [
+            { path: ".", registries: ["npm", "jsr"], ecosystem: "js" },
+          ],
+        },
       });
 
       expect(scriptsTask.skip(ctx)).toBe(false);
@@ -368,7 +359,9 @@ describe("requiredConditionsCheckTask", () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: { packages: [{ path: ".", registries: ["crates"] }] },
+        config: {
+          packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
+        },
       });
 
       expect(scriptsTask.skip(ctx)).toBe(true);

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -2028,7 +2028,18 @@ describe("normal pipeline test and build tasks", () => {
     const ctx: any = {
       options: { testScript: "test", mode: "local" as const },
       runtime: { pluginRunner },
-      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
+      config: {
+        packages: [
+          {
+            path: ".",
+            ecosystem: "js",
+            registries: ["npm"],
+            name: "my-package",
+            version: "1.0.0",
+            dependencies: [],
+          },
+        ],
+      },
     };
 
     await expect(testTask.task(ctx, task)).rejects.toThrow(
@@ -2057,7 +2068,18 @@ describe("normal pipeline test and build tasks", () => {
     const ctx: any = {
       options: { buildScript: "build", mode: "local" as const },
       runtime: { pluginRunner },
-      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
+      config: {
+        packages: [
+          {
+            path: ".",
+            ecosystem: "js",
+            registries: ["npm"],
+            name: "my-package",
+            version: "1.0.0",
+            dependencies: [],
+          },
+        ],
+      },
     };
 
     await expect(buildTask.task(ctx, task)).rejects.toThrow(
@@ -2091,7 +2113,18 @@ describe("normal pipeline test and build tasks", () => {
         mode: "local" as const,
       },
       runtime: { pluginRunner },
-      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
+      config: {
+        packages: [
+          {
+            path: ".",
+            ecosystem: "js",
+            registries: ["npm"],
+            name: "my-package",
+            version: "1.0.0",
+            dependencies: [],
+          },
+        ],
+      },
     };
 
     await testTask.task(ctx, createTask());

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -51,6 +51,12 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     manifestFiles() {
       return ["package.json"];
     }
+    defaultTestCommand() {
+      return Promise.resolve("pnpm run test");
+    }
+    defaultBuildCommand() {
+      return Promise.resolve("pnpm run build");
+    }
   }
   class MockRustEcosystem {
     packagePath: string;
@@ -59,6 +65,12 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     }
     manifestFiles() {
       return ["Cargo.toml"];
+    }
+    defaultTestCommand() {
+      return Promise.resolve("cargo test");
+    }
+    defaultBuildCommand() {
+      return Promise.resolve("cargo build --release");
     }
   }
   const descriptors: Record<string, any> = {
@@ -2016,10 +2028,11 @@ describe("normal pipeline test and build tasks", () => {
     const ctx: any = {
       options: { testScript: "test", mode: "local" as const },
       runtime: { pluginRunner },
+      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
     };
 
     await expect(testTask.task(ctx, task)).rejects.toThrow(
-      "Test script 'test' failed.",
+      "Test script 'pnpm run test' failed.",
     );
     expect(beforeTest).toHaveBeenCalledWith(ctx);
   });
@@ -2044,10 +2057,11 @@ describe("normal pipeline test and build tasks", () => {
     const ctx: any = {
       options: { buildScript: "build", mode: "local" as const },
       runtime: { pluginRunner },
+      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
     };
 
     await expect(buildTask.task(ctx, task)).rejects.toThrow(
-      "Build script 'build' failed.",
+      "Build script 'pnpm run build' failed.",
     );
     expect(beforeBuild).toHaveBeenCalledWith(ctx);
   });
@@ -2077,6 +2091,7 @@ describe("normal pipeline test and build tasks", () => {
         mode: "local" as const,
       },
       runtime: { pluginRunner },
+      config: { packages: [{ path: ".", ecosystem: "js", registries: ["npm"], name: "my-package", version: "1.0.0", dependencies: [] }] },
     };
 
     await testTask.task(ctx, createTask());

--- a/packages/core/tests/unit/tasks/runner.test.ts
+++ b/packages/core/tests/unit/tasks/runner.test.ts
@@ -925,6 +925,67 @@ describe("run", () => {
       expect(mockTask.output).toBe("Completed `pnpm run test`");
     });
 
+    it("treats packages with ecosystem: undefined as JS", async () => {
+      const options = createOptions({
+        config: {
+          packages: [
+            {
+              path: ".",
+              name: "my-package",
+              version: "1.0.0",
+              ecosystem: undefined as any,
+              dependencies: [],
+              registries: ["npm"],
+            },
+          ],
+        },
+      });
+      await run(options);
+
+      const callArgs = mockedCreateListr.mock.calls[0];
+      const tasks = callArgs[0] as any[];
+      const testTask = tasks[0];
+      const { task: mockTask } = createMockTaskRecorder();
+
+      await testTask.task(
+        { ...options, runtime: { ...options.runtime, promptEnabled: true } },
+        mockTask,
+      );
+
+      expect(mockTask.title).toBe("Running tests (pnpm run test)");
+    });
+
+    it("skips unknown ecosystems gracefully", async () => {
+      const options = createOptions({
+        config: {
+          packages: [
+            {
+              path: ".",
+              name: "my-package",
+              version: "1.0.0",
+              ecosystem: "unknown-eco" as any,
+              dependencies: [],
+              registries: ["npm"],
+            },
+          ],
+        },
+      });
+      await run(options);
+
+      const callArgs = mockedCreateListr.mock.calls[0];
+      const tasks = callArgs[0] as any[];
+      const testTask = tasks[0];
+      const { task: mockTask } = createMockTaskRecorder();
+
+      await testTask.task(
+        { ...options, runtime: { ...options.runtime, promptEnabled: true } },
+        mockTask,
+      );
+
+      // No commands executed, completion shows empty
+      expect(mockTask.output).toBe("Completed ``");
+    });
+
     it("shows only the latest 4 lines of live test output on local TTY", async () => {
       const originalIsTTY = process.stdout.isTTY;
       try {
@@ -1075,7 +1136,9 @@ describe("run", () => {
       // Error triggers catch block with context message
       expect(mockedConsoleError).toHaveBeenCalled();
       const errorArg = mockedConsoleError.mock.calls[0][0];
-      expect((errorArg as Error).message).toMatch(/Test script 'pnpm run test' failed/);
+      expect((errorArg as Error).message).toMatch(
+        /Test script 'pnpm run test' failed/,
+      );
     });
 
     it("runs test task successfully when no stderr", async () => {

--- a/packages/core/tests/unit/tasks/runner.test.ts
+++ b/packages/core/tests/unit/tasks/runner.test.ts
@@ -922,7 +922,7 @@ describe("run", () => {
       );
 
       expect(mockTask.title).toBe("Running tests (pnpm run test)");
-      expect(mockTask.output).toBe("Completed `js`");
+      expect(mockTask.output).toBe("Completed `pnpm run test`");
     });
 
     it("shows only the latest 4 lines of live test output on local TTY", async () => {

--- a/packages/core/tests/unit/tasks/runner.test.ts
+++ b/packages/core/tests/unit/tasks/runner.test.ts
@@ -36,6 +36,12 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     syncLockfile() {
       return Promise.resolve(undefined);
     }
+    defaultTestCommand() {
+      return Promise.resolve("pnpm run test");
+    }
+    defaultBuildCommand() {
+      return Promise.resolve("pnpm run build");
+    }
   }
   class MockRustEcosystem {
     packagePath: string;
@@ -47,6 +53,12 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     }
     syncLockfile() {
       return Promise.resolve(undefined);
+    }
+    defaultTestCommand() {
+      return Promise.resolve("cargo test");
+    }
+    defaultBuildCommand() {
+      return Promise.resolve("cargo build --release");
     }
   }
   const descriptors: Record<string, any> = {
@@ -910,7 +922,7 @@ describe("run", () => {
       );
 
       expect(mockTask.title).toBe("Running tests (pnpm run test)");
-      expect(mockTask.output).toBe("Completed `pnpm run test`");
+      expect(mockTask.output).toBe("Completed `js`");
     });
 
     it("shows only the latest 4 lines of live test output on local TTY", async () => {
@@ -1063,7 +1075,7 @@ describe("run", () => {
       // Error triggers catch block with context message
       expect(mockedConsoleError).toHaveBeenCalled();
       const errorArg = mockedConsoleError.mock.calls[0][0];
-      expect((errorArg as Error).message).toMatch(/Test script 'test' failed/);
+      expect((errorArg as Error).message).toMatch(/Test script 'pnpm run test' failed/);
     });
 
     it("runs test task successfully when no stderr", async () => {
@@ -1072,7 +1084,7 @@ describe("run", () => {
       const options = createOptions();
       await run(options);
 
-      expect(mockedGetPackageManager).toHaveBeenCalled();
+      expect(mockedExec).toHaveBeenCalled();
     });
 
     it("runs build task and throws on exec error", async () => {


### PR DESCRIPTION
## Summary
- Dispatch test/build commands per-ecosystem (`cargo test` for Rust, `<pm> run test` for JS) instead of hardcoding `npm run test`
- Replace `needsPackageScripts` registry flag with ecosystem-based skip condition in preflight checks
- Remove `needsPackageScripts` from `RegistryDescriptor`, `PackageRegistry`, `PluginRegistryDefinition`, and all registry registrations

## Test plan
- [x] All 1981 tests pass
- [x] Coverage thresholds met (95.57% statements, 90% branches, 95.41% functions, 96.04% lines)
- [x] Typecheck passes
- [ ] Manual test: run pubm on a pure Rust project (e.g. complete-checkpoint) — should use `cargo test`
- [ ] Manual test: run pubm on a JS+Rust project (e.g. chkpt) — should not ENOENT on package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)