### PR TITLE
feat(core): ecosystem-aware test/build execution model

### DIFF
--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import micromatch from "micromatch";
 import type { BumpType } from "../changeset/parser.js";
 import { ecosystemCatalog } from "../ecosystem/catalog.js";
 import { t } from "../i18n/index.js";
@@ -114,9 +115,14 @@ export async function resolveConfig(
     packages = [];
   } else {
     packages = discovered.map((pkg) => {
-      const configPkg = configPackages?.find(
-        (cp) => path.normalize(cp.path) === pkg.path,
-      );
+      const configPkg = configPackages?.find((cp) => {
+        const normalized = cp.path.replace(/\\/g, "/");
+        const pkgPathForward = pkg.path.replace(/\\/g, "/");
+        if (micromatch.scan(normalized).isGlob) {
+          return micromatch.isMatch(pkgPathForward, normalized);
+        }
+        return path.normalize(cp.path) === pkg.path;
+      });
       return {
         path: pkg.path,
         name: pkg.name,

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { BumpType } from "../changeset/parser.js";
 import { ecosystemCatalog } from "../ecosystem/catalog.js";
 import { t } from "../i18n/index.js";
@@ -74,6 +75,22 @@ export async function resolveConfig(
     }
   }
 
+  if (config.ecosystems) {
+    for (const key of Object.keys(config.ecosystems)) {
+      if (!ecosystemCatalog.get(key)) {
+        throw new Error(
+          t("error.config.unknownEcosystem", {
+            ecosystem: key,
+            list: ecosystemCatalog
+              .all()
+              .map((d) => d.key)
+              .join(", "),
+          }),
+        );
+      }
+    }
+  }
+
   // Normalize private registries in config packages before passing to discover
   const configPackages = config.packages?.map((pkg) => {
     if (!pkg.registries) return pkg;
@@ -96,17 +113,32 @@ export async function resolveConfig(
     discoveryEmpty = true;
     packages = [];
   } else {
-    packages = discovered.map((pkg) => ({
-      path: pkg.path,
-      name: pkg.name,
-      version: pkg.version,
-      dependencies: pkg.dependencies,
-      ecosystem: pkg.ecosystem,
-      registries: pkg.registries as RegistryType[],
-      ...(pkg.registryVersions
-        ? { registryVersions: pkg.registryVersions }
-        : {}),
-    }));
+    packages = discovered.map((pkg) => {
+      const configPkg = configPackages?.find(
+        (cp) => path.normalize(cp.path) === pkg.path,
+      );
+      return {
+        path: pkg.path,
+        name: pkg.name,
+        version: pkg.version,
+        dependencies: pkg.dependencies,
+        ecosystem: pkg.ecosystem,
+        registries: pkg.registries as RegistryType[],
+        ...(pkg.registryVersions
+          ? { registryVersions: pkg.registryVersions }
+          : {}),
+        ...(configPkg?.testScript ? { testScript: configPkg.testScript } : {}),
+        ...(configPkg?.testCommand
+          ? { testCommand: configPkg.testCommand }
+          : {}),
+        ...(configPkg?.buildScript
+          ? { buildScript: configPkg.buildScript }
+          : {}),
+        ...(configPkg?.buildCommand
+          ? { buildCommand: configPkg.buildCommand }
+          : {}),
+      };
+    });
   }
 
   return {
@@ -120,6 +152,7 @@ export async function resolveConfig(
       ...config.rollback,
     },
     snapshotTemplate: config.snapshotTemplate ?? defaultConfig.snapshotTemplate,
+    ecosystems: config.ecosystems ?? {},
     plugins: config.plugins ?? [],
     versionSources: config.versionSources ?? defaultConfig.versionSources,
     conventionalCommits: {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -8,12 +8,21 @@ export interface PrivateRegistryConfig {
   token: { envVar: string };
 }
 
+export interface EcosystemConfig {
+  testScript?: string;
+  testCommand?: string;
+  buildScript?: string;
+  buildCommand?: string;
+}
+
 export interface PackageConfig {
   path: string;
   registries?: (RegistryType | PrivateRegistryConfig)[];
   ecosystem?: string;
-  buildCommand?: string;
+  testScript?: string;
   testCommand?: string;
+  buildScript?: string;
+  buildCommand?: string;
 }
 
 export interface ResolvedPackageConfig
@@ -63,6 +72,7 @@ export interface PubmConfig {
   rollbackStrategy?: "individual" | "all";
   rollback?: RollbackConfig;
   lockfileSync?: "required" | "optional" | "skip";
+  ecosystems?: Record<string, EcosystemConfig>;
   plugins?: PubmPlugin[];
   compress?: CompressOption;
   releaseAssets?: ReleaseAssetEntry[];
@@ -92,6 +102,9 @@ export interface ResolvedPubmConfig
       | "locale"
       | "versionSources"
       | "conventionalCommits"
+      | "ecosystems"
+      | "testScript"
+      | "buildScript"
     >
   > {
   compress?: CompressOption;
@@ -105,6 +118,9 @@ export interface ResolvedPubmConfig
   conventionalCommits: {
     types: Record<string, BumpType | false>;
   };
+  ecosystems: Record<string, EcosystemConfig>;
+  testScript?: string;
+  buildScript?: string;
   discoveryEmpty?: boolean;
 }
 

--- a/packages/core/src/ecosystem/catalog.ts
+++ b/packages/core/src/ecosystem/catalog.ts
@@ -45,17 +45,17 @@ export class EcosystemCatalog {
 export const ecosystemCatalog: EcosystemCatalog = new EcosystemCatalog();
 
 ecosystemCatalog.register({
-  key: "js",
-  label: "JavaScript",
-  defaultRegistries: ["npm", "jsr"],
-  ecosystemClass: JsEcosystem,
-  detect: (path) => JsEcosystem.detect(path),
-});
-
-ecosystemCatalog.register({
   key: "rust",
   label: "Rust",
   defaultRegistries: ["crates"],
   ecosystemClass: RustEcosystem,
   detect: (path) => RustEcosystem.detect(path),
+});
+
+ecosystemCatalog.register({
+  key: "js",
+  label: "JavaScript",
+  defaultRegistries: ["npm", "jsr"],
+  ecosystemClass: JsEcosystem,
+  detect: (path) => JsEcosystem.detect(path),
 });

--- a/packages/core/src/ecosystem/ecosystem.ts
+++ b/packages/core/src/ecosystem/ecosystem.ts
@@ -13,8 +13,16 @@ export abstract class Ecosystem {
   abstract registryClasses(): (typeof PackageRegistry)[];
   abstract writeVersion(newVersion: string): Promise<void>;
   abstract manifestFiles(): string[];
-  abstract defaultTestCommand(scriptName?: string): Promise<string> | string;
-  abstract defaultBuildCommand(scriptName?: string): Promise<string> | string;
+  abstract resolveTestCommand(
+    script: string,
+  ): Promise<{ cmd: string; args: string[] }>;
+  abstract resolveBuildCommand(
+    script: string,
+  ): Promise<{ cmd: string; args: string[] }>;
+  abstract validateScript(
+    script: string,
+    type: "test" | "build",
+  ): Promise<string | null>;
   abstract supportedRegistries(): RegistryType[];
   abstract createDescriptor(): Promise<EcosystemDescriptor>;
 

--- a/packages/core/src/ecosystem/js.ts
+++ b/packages/core/src/ecosystem/js.ts
@@ -68,14 +68,35 @@ export class JsEcosystem extends Ecosystem {
     return ["package.json"];
   }
 
-  async defaultTestCommand(scriptName?: string): Promise<string> {
+  async resolveTestCommand(
+    script: string,
+  ): Promise<{ cmd: string; args: string[] }> {
     const pm = await getPackageManager();
-    return `${pm} run ${scriptName ?? "test"}`;
+    return { cmd: pm, args: ["run", script] };
   }
 
-  async defaultBuildCommand(scriptName?: string): Promise<string> {
+  async resolveBuildCommand(
+    script: string,
+  ): Promise<{ cmd: string; args: string[] }> {
     const pm = await getPackageManager();
-    return `${pm} run ${scriptName ?? "build"}`;
+    return { cmd: pm, args: ["run", script] };
+  }
+
+  async validateScript(
+    script: string,
+    _type: "test" | "build",
+  ): Promise<string | null> {
+    const pkgPath = path.join(this.packagePath, "package.json");
+    try {
+      const raw = await readFile(pkgPath, "utf-8");
+      const { scripts } = JSON.parse(raw);
+      if (!scripts?.[script]) {
+        return `Script '${script}' not found in ${pkgPath}`;
+      }
+      return null;
+    } catch {
+      return `Cannot read ${pkgPath}`;
+    }
   }
 
   supportedRegistries(): RegistryType[] {

--- a/packages/core/src/ecosystem/rust.ts
+++ b/packages/core/src/ecosystem/rust.ts
@@ -109,12 +109,23 @@ export class RustEcosystem extends Ecosystem {
     return ["Cargo.toml"];
   }
 
-  defaultTestCommand(_scriptName?: string): string {
-    return "cargo test";
+  resolveTestCommand(script: string): Promise<{ cmd: string; args: string[] }> {
+    const parts = script.split(/\s+/);
+    return Promise.resolve({ cmd: "cargo", args: parts });
   }
 
-  defaultBuildCommand(_scriptName?: string): string {
-    return "cargo build --release";
+  resolveBuildCommand(
+    script: string,
+  ): Promise<{ cmd: string; args: string[] }> {
+    const parts = script.split(/\s+/);
+    return Promise.resolve({ cmd: "cargo", args: parts });
+  }
+
+  validateScript(
+    _script: string,
+    _type: "test" | "build",
+  ): Promise<string | null> {
+    return Promise.resolve(null);
   }
 
   supportedRegistries(): RegistryType[] {

--- a/packages/core/src/tasks/phases/test-build.ts
+++ b/packages/core/src/tasks/phases/test-build.ts
@@ -1,40 +1,223 @@
+import path from "node:path";
 import type { ListrTask } from "listr2";
+import type { ResolvedPackageConfig } from "../../config/types.js";
 import type { PubmContext } from "../../context.js";
 import { ecosystemCatalog } from "../../ecosystem/catalog.js";
 import { AbstractError } from "../../error.js";
 import { t } from "../../i18n/index.js";
+import { detectWorkspace } from "../../monorepo/workspace.js";
 import { exec } from "../../utils/exec.js";
 import {
   createLiveCommandOutput,
   shouldRenderLiveCommandOutput,
 } from "../runner-utils/output-formatting.js";
 
-function collectUniqueEcosystems(ctx: PubmContext): string[] {
-  const seen = new Set<string>();
-  for (const pkg of ctx.config.packages) {
-    seen.add(pkg.ecosystem ?? "js");
-  }
-  return [...seen];
+interface ResolvedExecution {
+  label: string;
+  cmd: string;
+  args: string[];
+  cwd: string;
 }
 
-async function execEcosystemCommand(
+type CommandType = "test" | "build";
+
+const JS_WORKSPACE_TYPES = new Set(["pnpm", "npm", "yarn", "bun", "deno"]);
+
+const ECOSYSTEM_DEFAULTS: Record<string, Record<CommandType, string>> = {
+  js: { test: "test", build: "build" },
+  rust: { test: "test", build: "build --release" },
+};
+
+function hasWorkspaceForEcosystem(cwd: string, ecosystemKey: string): boolean {
+  const workspaces = detectWorkspace(cwd);
+  if (ecosystemKey === "js") {
+    return workspaces.some((w) => JS_WORKSPACE_TYPES.has(w.type));
+  }
+  if (ecosystemKey === "rust") {
+    return workspaces.some((w) => w.type === "cargo");
+  }
+  return false;
+}
+
+function hasPackageLevelOverride(
+  pkg: ResolvedPackageConfig,
+  type: CommandType,
+): boolean {
+  return type === "test"
+    ? !!(pkg.testCommand || pkg.testScript)
+    : !!(pkg.buildCommand || pkg.buildScript);
+}
+
+function resolveScript(
+  pkg: ResolvedPackageConfig,
+  ecosystemKey: string,
+  ctx: PubmContext,
+  type: CommandType,
+): { script?: string; command?: string } {
+  const sf = type === "test" ? "testScript" : "buildScript";
+  const cf = type === "test" ? "testCommand" : "buildCommand";
+
+  if (pkg[cf]) return { command: pkg[cf] };
+  if (pkg[sf]) return { script: pkg[sf] };
+
+  const eco = ctx.config.ecosystems?.[ecosystemKey];
+  if (eco?.[cf]) return { command: eco[cf] };
+  if (eco?.[sf]) return { script: eco[sf] };
+
+  const globalScript =
+    type === "test" ? ctx.options.testScript : ctx.options.buildScript;
+  if (globalScript) return { script: globalScript };
+
+  return { script: ECOSYSTEM_DEFAULTS[ecosystemKey]?.[type] ?? type };
+}
+
+interface EcosystemGroup {
+  ecosystemKey: string;
+  groupPackages: ResolvedPackageConfig[];
+  individualPackages: ResolvedPackageConfig[];
+  hasWorkspace: boolean;
+}
+
+function groupByEcosystem(
+  ctx: PubmContext,
+  type: CommandType,
+): EcosystemGroup[] {
+  const map = new Map<
+    string,
+    { group: ResolvedPackageConfig[]; individual: ResolvedPackageConfig[] }
+  >();
+
+  for (const pkg of ctx.config.packages) {
+    const key = pkg.ecosystem ?? "js";
+    if (!map.has(key)) map.set(key, { group: [], individual: [] });
+    const entry = map.get(key)!;
+    if (hasPackageLevelOverride(pkg, type)) {
+      entry.individual.push(pkg);
+    } else {
+      entry.group.push(pkg);
+    }
+  }
+
+  const result: EcosystemGroup[] = [];
+  for (const descriptor of ecosystemCatalog.all()) {
+    const entry = map.get(descriptor.key);
+    if (!entry) continue;
+    if (entry.group.length === 0 && entry.individual.length === 0) continue;
+    result.push({
+      ecosystemKey: descriptor.key,
+      groupPackages: entry.group,
+      individualPackages: entry.individual,
+      hasWorkspace: hasWorkspaceForEcosystem(ctx.cwd, descriptor.key),
+    });
+  }
+  return result;
+}
+
+async function resolveExecutions(
+  ctx: PubmContext,
+  type: CommandType,
+): Promise<ResolvedExecution[]> {
+  const groups = groupByEcosystem(ctx, type);
+  const executions: ResolvedExecution[] = [];
+
+  for (const group of groups) {
+    const descriptor = ecosystemCatalog.get(group.ecosystemKey);
+    if (!descriptor) continue;
+
+    if (group.groupPackages.length > 0) {
+      const resolved = resolveScript(
+        group.groupPackages[0],
+        group.ecosystemKey,
+        ctx,
+        type,
+      );
+
+      if (resolved.command) {
+        executions.push({
+          label: resolved.command,
+          cmd: "sh",
+          args: ["-c", resolved.command],
+          cwd: ctx.cwd,
+        });
+      } else if (resolved.script) {
+        if (group.hasWorkspace) {
+          const instance = new descriptor.ecosystemClass(ctx.cwd);
+          const { cmd, args } =
+            type === "test"
+              ? await instance.resolveTestCommand(resolved.script)
+              : await instance.resolveBuildCommand(resolved.script);
+          executions.push({
+            label: `${cmd} ${args.join(" ")}`,
+            cmd,
+            args,
+            cwd: ctx.cwd,
+          });
+        } else {
+          for (const pkg of group.groupPackages) {
+            const pkgCwd = path.resolve(ctx.cwd, pkg.path);
+            const instance = new descriptor.ecosystemClass(pkgCwd);
+            const { cmd, args } =
+              type === "test"
+                ? await instance.resolveTestCommand(resolved.script)
+                : await instance.resolveBuildCommand(resolved.script);
+            executions.push({
+              label: `${cmd} ${args.join(" ")} (${pkg.path})`,
+              cmd,
+              args,
+              cwd: pkgCwd,
+            });
+          }
+        }
+      }
+    }
+
+    for (const pkg of group.individualPackages) {
+      const pkgCwd = path.resolve(ctx.cwd, pkg.path);
+      const resolved = resolveScript(pkg, group.ecosystemKey, ctx, type);
+
+      if (resolved.command) {
+        executions.push({
+          label: `${resolved.command} (${pkg.path})`,
+          cmd: "sh",
+          args: ["-c", resolved.command],
+          cwd: pkgCwd,
+        });
+      } else if (resolved.script) {
+        const instance = new descriptor.ecosystemClass(pkgCwd);
+        const { cmd, args } =
+          type === "test"
+            ? await instance.resolveTestCommand(resolved.script)
+            : await instance.resolveBuildCommand(resolved.script);
+        executions.push({
+          label: `${cmd} ${args.join(" ")} (${pkg.path})`,
+          cmd,
+          args,
+          cwd: pkgCwd,
+        });
+      }
+    }
+  }
+
+  return executions;
+}
+
+async function runExecution(
+  execution: ResolvedExecution,
   ctx: PubmContext,
   // biome-ignore lint/suspicious/noExplicitAny: listr2 TaskWrapper type is complex
   task: any,
-  command: string,
 ): Promise<void> {
-  const parts = command.split(/\s+/);
-  const [cmd, ...args] = parts;
   const liveOutput = shouldRenderLiveCommandOutput(ctx)
-    ? createLiveCommandOutput(task, command)
+    ? createLiveCommandOutput(task, execution.label)
     : undefined;
-  task.output = `Executing \`${command}\``;
+  task.output = `Executing \`${execution.label}\``;
 
   try {
-    await exec(cmd, args, {
+    await exec(execution.cmd, execution.args, {
       onStdout: liveOutput?.onStdout,
       onStderr: liveOutput?.onStderr,
       throwOnError: true,
+      nodeOptions: { cwd: execution.cwd },
     });
   } finally {
     liveOutput?.finish();
@@ -52,25 +235,18 @@ export function createTestTask(
       task.output = t("task.test.runningBeforeHooks");
       await ctx.runtime.pluginRunner.runHook("beforeTest", ctx);
 
-      const ecosystems = collectUniqueEcosystems(ctx);
-      const executedCommands: string[] = [];
-      for (const key of ecosystems) {
-        const descriptor = ecosystemCatalog.get(key);
-        if (!descriptor) continue;
-        const instance = new descriptor.ecosystemClass(ctx.cwd);
-        const command = await instance.defaultTestCommand(
-          ctx.options.testScript,
-        );
-        executedCommands.push(command);
-        task.title = t("task.test.titleWithCommand", { command });
-
+      const executions = await resolveExecutions(ctx, "test");
+      for (const execution of executions) {
+        task.title = t("task.test.titleWithCommand", {
+          command: execution.label,
+        });
         try {
-          await execEcosystemCommand(ctx, task, command);
+          await runExecution(execution, ctx, task);
         } catch (error) {
           throw new AbstractError(
             t("error.test.failedWithHint", {
-              script: command,
-              command,
+              script: execution.label,
+              command: execution.label,
             }),
             { cause: error },
           );
@@ -80,7 +256,7 @@ export function createTestTask(
       task.output = t("task.test.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterTest", ctx);
       task.output = t("task.test.completed", {
-        command: executedCommands.join(", "),
+        command: executions.map((e) => e.label).join(", "),
       });
     },
   };
@@ -97,25 +273,18 @@ export function createBuildTask(
       task.output = t("task.build.runningBeforeHooks");
       await ctx.runtime.pluginRunner.runHook("beforeBuild", ctx);
 
-      const ecosystems = collectUniqueEcosystems(ctx);
-      const executedCommands: string[] = [];
-      for (const key of ecosystems) {
-        const descriptor = ecosystemCatalog.get(key);
-        if (!descriptor) continue;
-        const instance = new descriptor.ecosystemClass(ctx.cwd);
-        const command = await instance.defaultBuildCommand(
-          ctx.options.buildScript,
-        );
-        executedCommands.push(command);
-        task.title = t("task.build.titleWithCommand", { command });
-
+      const executions = await resolveExecutions(ctx, "build");
+      for (const execution of executions) {
+        task.title = t("task.build.titleWithCommand", {
+          command: execution.label,
+        });
         try {
-          await execEcosystemCommand(ctx, task, command);
+          await runExecution(execution, ctx, task);
         } catch (error) {
           throw new AbstractError(
             t("error.build.failedWithHint", {
-              script: command,
-              command,
+              script: execution.label,
+              command: execution.label,
             }),
             { cause: error },
           );
@@ -125,7 +294,7 @@ export function createBuildTask(
       task.output = t("task.build.runningAfterHooks");
       await ctx.runtime.pluginRunner.runHook("afterBuild", ctx);
       task.output = t("task.build.completed", {
-        command: executedCommands.join(", "),
+        command: executions.map((e) => e.label).join(", "),
       });
     },
   };

--- a/packages/core/src/tasks/phases/test-build.ts
+++ b/packages/core/src/tasks/phases/test-build.ts
@@ -125,6 +125,8 @@ async function resolveExecutions(
     if (!descriptor) continue;
 
     if (group.groupPackages.length > 0) {
+      // Safe to use [0]: group packages have no per-package overrides,
+      // so they all resolve identically through ecosystem/global/default levels.
       const resolved = resolveScript(
         group.groupPackages[0],
         group.ecosystemKey,

--- a/packages/core/src/tasks/phases/test-build.ts
+++ b/packages/core/src/tasks/phases/test-build.ts
@@ -135,12 +135,24 @@ async function resolveExecutions(
       );
 
       if (resolved.command) {
-        executions.push({
-          label: resolved.command,
-          cmd: "sh",
-          args: ["-c", resolved.command],
-          cwd: ctx.cwd,
-        });
+        if (group.hasWorkspace) {
+          executions.push({
+            label: resolved.command,
+            cmd: "sh",
+            args: ["-c", resolved.command],
+            cwd: ctx.cwd,
+          });
+        } else {
+          for (const pkg of group.groupPackages) {
+            const pkgCwd = path.resolve(ctx.cwd, pkg.path);
+            executions.push({
+              label: `${resolved.command} (${pkg.path})`,
+              cmd: "sh",
+              args: ["-c", resolved.command],
+              cwd: pkgCwd,
+            });
+          }
+        }
       } else if (resolved.script) {
         if (group.hasWorkspace) {
           const instance = new descriptor.ecosystemClass(ctx.cwd);

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -1,11 +1,13 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 import type { Listr, ListrTask } from "listr2";
 import { isCI } from "std-env";
+import type { ResolvedPackageConfig } from "../config/types.js";
 import type { PubmContext } from "../context.js";
+import { ecosystemCatalog } from "../ecosystem/catalog.js";
 import { AbstractError } from "../error.js";
 import { Git } from "../git.js";
 import { t } from "../i18n/index.js";
+import { detectWorkspace } from "../monorepo/workspace.js";
 import { wrapTaskContext } from "../plugin/wrap-task-context.js";
 import { registryCatalog } from "../registry/catalog.js";
 import { getConnector } from "../registry/index.js";
@@ -103,39 +105,99 @@ export const requiredConditionsCheckTask = (
           },
           {
             title: t("task.conditions.checkScripts"),
-            skip: (ctx) =>
-              !ctx.config.packages.some(
-                (pkg) => (pkg.ecosystem ?? "js") === "js",
-              ),
+            skip: (ctx) => !!ctx.options.skipTests && !!ctx.options.skipBuild,
             task: async (ctx): Promise<void> => {
-              const raw = await readFile(
-                join(ctx.cwd, "package.json"),
-                "utf-8",
-              );
-              const { scripts } = JSON.parse(raw);
-
               const errors: string[] = [];
+              const JS_WS_TYPES = new Set([
+                "pnpm",
+                "npm",
+                "yarn",
+                "bun",
+                "deno",
+              ]);
+              const workspaces = detectWorkspace(ctx.cwd);
 
-              if (
-                !ctx.options.skipTests &&
-                !scripts?.[ctx.options.testScript]
-              ) {
-                errors.push(
-                  t("error.conditions.testScriptMissing", {
-                    script: ctx.options.testScript,
-                  }),
-                );
+              const byEcosystem = new Map<string, ResolvedPackageConfig[]>();
+              for (const pkg of ctx.config.packages) {
+                const key = pkg.ecosystem ?? "js";
+                if (!byEcosystem.has(key)) byEcosystem.set(key, []);
+                byEcosystem.get(key)!.push(pkg);
               }
 
-              if (
-                !ctx.options.skipBuild &&
-                !scripts?.[ctx.options.buildScript]
-              ) {
-                errors.push(
-                  t("error.conditions.buildScriptMissing", {
-                    script: ctx.options.buildScript,
-                  }),
-                );
+              for (const [ecosystemKey, packages] of byEcosystem) {
+                const descriptor = ecosystemCatalog.get(ecosystemKey);
+                if (!descriptor) continue;
+
+                const hasWorkspace =
+                  ecosystemKey === "js"
+                    ? workspaces.some((w) => JS_WS_TYPES.has(w.type))
+                    : ecosystemKey === "rust"
+                      ? workspaces.some((w) => w.type === "cargo")
+                      : false;
+
+                const ecoConfig = ctx.config.ecosystems?.[ecosystemKey];
+                let groupValidated = false;
+
+                for (const pkg of packages) {
+                  if (!ctx.options.skipTests) {
+                    const hasCommand =
+                      pkg.testCommand ?? ecoConfig?.testCommand;
+                    if (!hasCommand) {
+                      const script =
+                        pkg.testScript ??
+                        ecoConfig?.testScript ??
+                        ctx.options.testScript;
+                      const isPackageOverride = !!pkg.testScript;
+                      const validateCwd =
+                        hasWorkspace && !isPackageOverride
+                          ? ctx.cwd
+                          : path.resolve(ctx.cwd, pkg.path);
+
+                      if (hasWorkspace && !isPackageOverride && groupValidated)
+                        continue;
+
+                      const instance = new descriptor.ecosystemClass(
+                        validateCwd,
+                      );
+                      const error = await instance.validateScript(
+                        script,
+                        "test",
+                      );
+                      if (error) errors.push(error);
+
+                      if (hasWorkspace && !isPackageOverride)
+                        groupValidated = true;
+                    }
+                  }
+
+                  if (!ctx.options.skipBuild) {
+                    const hasCommand =
+                      pkg.buildCommand ?? ecoConfig?.buildCommand;
+                    if (!hasCommand) {
+                      const script =
+                        pkg.buildScript ??
+                        ecoConfig?.buildScript ??
+                        ctx.options.buildScript;
+                      const isPackageOverride = !!pkg.buildScript;
+                      const validateCwd =
+                        hasWorkspace && !isPackageOverride
+                          ? ctx.cwd
+                          : path.resolve(ctx.cwd, pkg.path);
+
+                      if (hasWorkspace && !isPackageOverride && groupValidated)
+                        continue;
+
+                      const instance = new descriptor.ecosystemClass(
+                        validateCwd,
+                      );
+                      const error = await instance.validateScript(
+                        script,
+                        "build",
+                      );
+                      if (error) errors.push(error);
+                    }
+                  }
+                }
               }
 
               if (errors.length) {

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -155,23 +155,22 @@ export const requiredConditionsCheckTask = (
                           : path.resolve(ctx.cwd, pkg.path);
 
                       if (
-                        hasWorkspace &&
-                        !isPackageOverride &&
-                        testGroupValidated
-                      )
-                        continue;
+                        !hasWorkspace ||
+                        isPackageOverride ||
+                        !testGroupValidated
+                      ) {
+                        const instance = new descriptor.ecosystemClass(
+                          validateCwd,
+                        );
+                        const error = await instance.validateScript(
+                          script,
+                          "test",
+                        );
+                        if (error) errors.push(error);
 
-                      const instance = new descriptor.ecosystemClass(
-                        validateCwd,
-                      );
-                      const error = await instance.validateScript(
-                        script,
-                        "test",
-                      );
-                      if (error) errors.push(error);
-
-                      if (hasWorkspace && !isPackageOverride)
-                        testGroupValidated = true;
+                        if (hasWorkspace && !isPackageOverride)
+                          testGroupValidated = true;
+                      }
                     }
                   }
 
@@ -190,23 +189,22 @@ export const requiredConditionsCheckTask = (
                           : path.resolve(ctx.cwd, pkg.path);
 
                       if (
-                        hasWorkspace &&
-                        !isPackageOverride &&
-                        buildGroupValidated
-                      )
-                        continue;
+                        !hasWorkspace ||
+                        isPackageOverride ||
+                        !buildGroupValidated
+                      ) {
+                        const instance = new descriptor.ecosystemClass(
+                          validateCwd,
+                        );
+                        const error = await instance.validateScript(
+                          script,
+                          "build",
+                        );
+                        if (error) errors.push(error);
 
-                      const instance = new descriptor.ecosystemClass(
-                        validateCwd,
-                      );
-                      const error = await instance.validateScript(
-                        script,
-                        "build",
-                      );
-                      if (error) errors.push(error);
-
-                      if (hasWorkspace && !isPackageOverride)
-                        buildGroupValidated = true;
+                        if (hasWorkspace && !isPackageOverride)
+                          buildGroupValidated = true;
+                      }
                     }
                   }
                 }

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -136,7 +136,8 @@ export const requiredConditionsCheckTask = (
                       : false;
 
                 const ecoConfig = ctx.config.ecosystems?.[ecosystemKey];
-                let groupValidated = false;
+                let testGroupValidated = false;
+                let buildGroupValidated = false;
 
                 for (const pkg of packages) {
                   if (!ctx.options.skipTests) {
@@ -153,7 +154,11 @@ export const requiredConditionsCheckTask = (
                           ? ctx.cwd
                           : path.resolve(ctx.cwd, pkg.path);
 
-                      if (hasWorkspace && !isPackageOverride && groupValidated)
+                      if (
+                        hasWorkspace &&
+                        !isPackageOverride &&
+                        testGroupValidated
+                      )
                         continue;
 
                       const instance = new descriptor.ecosystemClass(
@@ -166,7 +171,7 @@ export const requiredConditionsCheckTask = (
                       if (error) errors.push(error);
 
                       if (hasWorkspace && !isPackageOverride)
-                        groupValidated = true;
+                        testGroupValidated = true;
                     }
                   }
 
@@ -184,7 +189,11 @@ export const requiredConditionsCheckTask = (
                           ? ctx.cwd
                           : path.resolve(ctx.cwd, pkg.path);
 
-                      if (hasWorkspace && !isPackageOverride && groupValidated)
+                      if (
+                        hasWorkspace &&
+                        !isPackageOverride &&
+                        buildGroupValidated
+                      )
                         continue;
 
                       const instance = new descriptor.ecosystemClass(
@@ -195,6 +204,9 @@ export const requiredConditionsCheckTask = (
                         "build",
                       );
                       if (error) errors.push(error);
+
+                      if (hasWorkspace && !isPackageOverride)
+                        buildGroupValidated = true;
                     }
                   }
                 }

--- a/packages/core/tests/helpers/make-context.ts
+++ b/packages/core/tests/helpers/make-context.ts
@@ -26,6 +26,7 @@ export function makeTestConfig(
     rollback: { strategy: "individual", dangerouslyAllowUnpublish: false },
     lockfileSync: "optional",
     packages: [],
+    ecosystems: {},
     validate: { cleanInstall: true, entryPoints: true, extraneousFiles: true },
     plugins: [],
     ...overrides,

--- a/packages/core/tests/unit/config/defaults.test.ts
+++ b/packages/core/tests/unit/config/defaults.test.ts
@@ -148,6 +148,77 @@ describe("resolveConfig", () => {
     ]);
   });
 
+  describe("glob pattern config packages", () => {
+    it("applies testScript/buildScript from a glob config entry to all matched discovered packages", async () => {
+      mockedDiscoverPackages.mockResolvedValue([
+        {
+          path: "packages/a",
+          name: "pkg-a",
+          version: "1.0.0",
+          dependencies: [],
+          registries: ["npm"],
+          ecosystem: "js",
+        },
+        {
+          path: "packages/b",
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: [],
+          registries: ["npm"],
+          ecosystem: "js",
+        },
+      ]);
+
+      const resolved = await resolveConfig({
+        packages: [
+          {
+            path: "packages/*",
+            testScript: "test:ci",
+            buildScript: "build:prod",
+          },
+        ],
+      });
+
+      expect(resolved.packages[0].testScript).toBe("test:ci");
+      expect(resolved.packages[0].buildScript).toBe("build:prod");
+      expect(resolved.packages[1].testScript).toBe("test:ci");
+      expect(resolved.packages[1].buildScript).toBe("build:prod");
+    });
+
+    it("does not apply glob config overrides to non-matching packages", async () => {
+      mockedDiscoverPackages.mockResolvedValue([
+        {
+          path: "packages/a",
+          name: "pkg-a",
+          version: "1.0.0",
+          dependencies: [],
+          registries: ["npm"],
+          ecosystem: "js",
+        },
+        {
+          path: "tools/cli",
+          name: "cli",
+          version: "1.0.0",
+          dependencies: [],
+          registries: ["npm"],
+          ecosystem: "js",
+        },
+      ]);
+
+      const resolved = await resolveConfig({
+        packages: [
+          {
+            path: "packages/*",
+            testScript: "test:ci",
+          },
+        ],
+      });
+
+      expect(resolved.packages[0].testScript).toBe("test:ci");
+      expect(resolved.packages[1].testScript).toBeUndefined();
+    });
+  });
+
   it("migrates deprecated rollbackStrategy to rollback.strategy", async () => {
     const resolved = await resolveConfig({ rollbackStrategy: "all" });
     expect(resolved.rollback.strategy).toBe("all");

--- a/packages/core/tests/unit/ecosystem/js.test.ts
+++ b/packages/core/tests/unit/ecosystem/js.test.ts
@@ -189,19 +189,45 @@ describe("JsEcosystem", () => {
     });
   });
 
-  describe("defaultTestCommand", () => {
-    it("returns <pm> run test", async () => {
+  describe("resolveTestCommand", () => {
+    it("returns { cmd, args } for the given script", async () => {
       mockedGetPackageManager.mockResolvedValue("pnpm");
       const eco = new JsEcosystem(pkgPath);
-      expect(await eco.defaultTestCommand()).toBe("pnpm run test");
+      const result = await eco.resolveTestCommand("test");
+      expect(result).toEqual({ cmd: "pnpm", args: ["run", "test"] });
     });
   });
 
-  describe("defaultBuildCommand", () => {
-    it("returns <pm> run build", async () => {
+  describe("resolveBuildCommand", () => {
+    it("returns { cmd, args } for the given script", async () => {
       mockedGetPackageManager.mockResolvedValue("npm");
       const eco = new JsEcosystem(pkgPath);
-      expect(await eco.defaultBuildCommand()).toBe("npm run build");
+      const result = await eco.resolveBuildCommand("build");
+      expect(result).toEqual({ cmd: "npm", args: ["run", "build"] });
+    });
+  });
+
+  describe("validateScript", () => {
+    it("returns null when script exists in package.json", async () => {
+      mockedReadFile.mockResolvedValue(
+        JSON.stringify({ scripts: { test: "vitest" } }) as any,
+      );
+      const eco = new JsEcosystem(pkgPath);
+      expect(await eco.validateScript("test", "test")).toBeNull();
+    });
+
+    it("returns error when script is missing", async () => {
+      mockedReadFile.mockResolvedValue(JSON.stringify({ scripts: {} }) as any);
+      const eco = new JsEcosystem(pkgPath);
+      const result = await eco.validateScript("test", "test");
+      expect(result).toContain("Script 'test' not found");
+    });
+
+    it("returns error when package.json cannot be read", async () => {
+      mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+      const eco = new JsEcosystem(pkgPath);
+      const result = await eco.validateScript("test", "test");
+      expect(result).toContain("Cannot read");
     });
   });
 

--- a/packages/core/tests/unit/ecosystem/rust.test.ts
+++ b/packages/core/tests/unit/ecosystem/rust.test.ts
@@ -110,17 +110,30 @@ serde = { version = "1.0.0", features = ["derive"] }
     });
   });
 
-  describe("defaultTestCommand", () => {
-    it("returns cargo test", () => {
+  describe("resolveTestCommand", () => {
+    it("returns { cmd, args } for the given script", async () => {
       const eco = new RustEcosystem(pkgPath);
-      expect(eco.defaultTestCommand()).toBe("cargo test");
+      expect(await eco.resolveTestCommand("test")).toEqual({
+        cmd: "cargo",
+        args: ["test"],
+      });
     });
   });
 
-  describe("defaultBuildCommand", () => {
-    it("returns cargo build --release", () => {
+  describe("resolveBuildCommand", () => {
+    it("returns { cmd, args } for the given script", async () => {
       const eco = new RustEcosystem(pkgPath);
-      expect(eco.defaultBuildCommand()).toBe("cargo build --release");
+      expect(await eco.resolveBuildCommand("build --release")).toEqual({
+        cmd: "cargo",
+        args: ["build", "--release"],
+      });
+    });
+  });
+
+  describe("validateScript", () => {
+    it("always returns null (Rust has no script validation)", async () => {
+      const eco = new RustEcosystem(pkgPath);
+      expect(await eco.validateScript("test", "test")).toBeNull();
     });
   });
 

--- a/packages/core/tests/unit/tasks/required-conditions-check.test.ts
+++ b/packages/core/tests/unit/tasks/required-conditions-check.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockValidateScript = vi.hoisted(() => vi.fn(() => Promise.resolve(null)));
+
 vi.mock("std-env", () => ({ isCI: false }));
 
 vi.mock("../../../src/git.js", () => ({
@@ -19,6 +21,40 @@ vi.mock("../../../src/registry/catalog.js", () => ({
 vi.mock("../../../src/utils/engine-version.js", () => ({
   validateEngineVersion: vi.fn(),
 }));
+
+vi.mock("../../../src/monorepo/workspace.js", () => ({
+  detectWorkspace: vi.fn(() => []),
+}));
+
+vi.mock("../../../src/ecosystem/catalog.js", () => {
+  class MockEcosystem {
+    packagePath: string;
+    constructor(p: string) {
+      this.packagePath = p;
+    }
+    validateScript(script: string, type: string) {
+      return mockValidateScript(script, type);
+    }
+  }
+  const descriptors: Record<string, any> = {
+    js: {
+      key: "js",
+      label: "JavaScript",
+      ecosystemClass: MockEcosystem,
+    },
+    rust: {
+      key: "rust",
+      label: "Rust",
+      ecosystemClass: MockEcosystem,
+    },
+  };
+  return {
+    ecosystemCatalog: {
+      get: vi.fn((key: string) => descriptors[key]),
+      all: vi.fn(() => Object.values(descriptors)),
+    },
+  };
+});
 
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn(),
@@ -107,6 +143,7 @@ async function getSubtasks() {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mockValidateScript.mockReset().mockReturnValue(Promise.resolve(null));
 
   vi.resetModules();
 
@@ -132,6 +169,40 @@ beforeEach(async () => {
   vi.doMock("../../../src/utils/engine-version.js", () => ({
     validateEngineVersion: vi.fn(),
   }));
+
+  vi.doMock("../../../src/monorepo/workspace.js", () => ({
+    detectWorkspace: vi.fn(() => []),
+  }));
+
+  vi.doMock("../../../src/ecosystem/catalog.js", () => {
+    class MockEcosystem {
+      packagePath: string;
+      constructor(p: string) {
+        this.packagePath = p;
+      }
+      validateScript(script: string, type: string) {
+        return mockValidateScript(script, type);
+      }
+    }
+    const descriptors: Record<string, any> = {
+      js: {
+        key: "js",
+        label: "JavaScript",
+        ecosystemClass: MockEcosystem,
+      },
+      rust: {
+        key: "rust",
+        label: "Rust",
+        ecosystemClass: MockEcosystem,
+      },
+    };
+    return {
+      ecosystemCatalog: {
+        get: vi.fn((key: string) => descriptors[key]),
+        all: vi.fn(() => Object.values(descriptors)),
+      },
+    };
+  });
 
   vi.doMock("node:fs/promises", () => ({
     readFile: vi.fn(),
@@ -329,144 +400,121 @@ describe("requiredConditionsCheckTask", () => {
   });
 
   describe("Subtask 2: Scripts existence check", () => {
-    it("skips when no JS ecosystem packages exist (e.g., crates only)", async () => {
+    it("skips when both skipTests and skipBuild are true", async () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: {
-          packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
-        },
+        options: { skipTests: true, skipBuild: true },
       });
 
       expect(scriptsTask.skip(ctx)).toBe(true);
     });
 
-    it("does not skip when JS ecosystem packages exist", async () => {
+    it("does not skip when skipTests is false", async () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: {
-          packages: [
-            { path: ".", registries: ["npm", "jsr"], ecosystem: "js" },
-          ],
-        },
+        options: { skipTests: false, skipBuild: true },
       });
 
       expect(scriptsTask.skip(ctx)).toBe(false);
     });
 
-    it("skips when registries contain only crates", async () => {
+    it("does not skip when skipBuild is false", async () => {
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
-        config: {
-          packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
-        },
+        options: { skipTests: true, skipBuild: false },
       });
 
-      expect(scriptsTask.skip(ctx)).toBe(true);
+      expect(scriptsTask.skip(ctx)).toBe(false);
     });
 
-    it("passes when both test and build scripts exist", async () => {
+    it("passes when validateScript returns null for all packages", async () => {
+      mockValidateScript.mockResolvedValue(null);
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "test", buildScript: "build" },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { test: "vitest", build: "tsup" },
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
     });
 
-    it("throws when test script is missing and skipTests is false", async () => {
+    it("throws when test script validation fails and skipTests is false", async () => {
+      mockValidateScript.mockImplementation((script: string, type: string) => {
+        if (type === "test")
+          return Promise.resolve(
+            `Script '${script}' not found in /fake/package.json`,
+          );
+        return Promise.resolve(null);
+      });
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "test", buildScript: "build", skipTests: false },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { build: "tsup" },
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).rejects.toThrow(
-        "Test script 'test' does not exist",
+        "Script 'test' not found",
       );
     });
 
-    it("passes when test script is missing but skipTests is true", async () => {
+    it("passes when test script validation fails but skipTests is true", async () => {
+      mockValidateScript.mockImplementation((script: string, type: string) => {
+        if (type === "test")
+          return Promise.resolve(`Script '${script}' not found`);
+        return Promise.resolve(null);
+      });
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "test", buildScript: "build", skipTests: true },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { build: "tsup" },
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
     });
 
-    it("throws when build script is missing and skipBuild is false", async () => {
+    it("throws when build script validation fails and skipBuild is false", async () => {
+      mockValidateScript.mockImplementation((script: string, type: string) => {
+        if (type === "build")
+          return Promise.resolve(
+            `Script '${script}' not found in /fake/package.json`,
+          );
+        return Promise.resolve(null);
+      });
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "test", buildScript: "build", skipBuild: false },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { test: "vitest" },
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).rejects.toThrow(
-        "Build script 'build' does not exist",
+        "Script 'build' not found",
       );
     });
 
-    it("passes when build script is missing but skipBuild is true", async () => {
+    it("passes when build script validation fails but skipBuild is true", async () => {
+      mockValidateScript.mockImplementation((script: string, type: string) => {
+        if (type === "build")
+          return Promise.resolve(`Script '${script}' not found`);
+        return Promise.resolve(null);
+      });
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "test", buildScript: "build", skipBuild: true },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { test: "vitest" },
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
     });
 
-    it("throws with combined message when both scripts are missing", async () => {
+    it("throws with combined message when both scripts validation fails", async () => {
+      mockValidateScript.mockImplementation((script: string) => {
+        return Promise.resolve(
+          `Script '${script}' not found in /fake/package.json`,
+        );
+      });
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
@@ -478,21 +526,13 @@ describe("requiredConditionsCheckTask", () => {
         },
       });
 
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: {},
-        }) as any,
-      );
-
       await expect(scriptsTask.task(ctx)).rejects.toThrow(
-        "Test script 'test' does not exist. and Build script 'build' does not exist.",
+        "Please check your configuration",
       );
     });
 
-    it("handles package.json with no scripts field", async () => {
+    it("throws when validateScript returns error for package", async () => {
+      mockValidateScript.mockResolvedValue("Cannot read /fake/package.json");
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
@@ -503,14 +543,6 @@ describe("requiredConditionsCheckTask", () => {
           skipBuild: false,
         },
       });
-
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-        }) as any,
-      );
 
       await expect(scriptsTask.task(ctx)).rejects.toThrow(
         "Please check your configuration",
@@ -518,20 +550,12 @@ describe("requiredConditionsCheckTask", () => {
     });
 
     it("uses custom script names from ctx", async () => {
+      mockValidateScript.mockResolvedValue(null);
       const subtasks = await getSubtasks();
       const scriptsTask = subtasks[1];
       const ctx = createCtx({
         options: { testScript: "custom-test", buildScript: "custom-build" },
       });
-
-      const { readFile: mockReadFile } = await import("node:fs/promises");
-      vi.mocked(mockReadFile).mockResolvedValue(
-        JSON.stringify({
-          name: "my-package",
-          version: "1.0.0",
-          scripts: { "custom-test": "vitest", "custom-build": "tsup" },
-        }) as any,
-      );
 
       await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
     });
@@ -1055,6 +1079,332 @@ describe("requiredConditionsCheckTask", () => {
       expect(registrySubtasks).toHaveLength(2);
       expect(registrySubtasks[0].title).toBe("Checking npm availability");
       expect(registrySubtasks[1].title).toBe("Checking jsr availability");
+    });
+  });
+
+  describe("Subtask 2: Scripts check — ecosystem and command branches", () => {
+    it("defaults to js ecosystem when pkg.ecosystem is undefined", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [{ path: ".", registries: ["npm"] } as any],
+        },
+        options: { testScript: "test", buildScript: "build" },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+    });
+
+    it("skips validation when testCommand is set on package", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: ".",
+              registries: ["npm"],
+              ecosystem: "js",
+              testCommand: "make test",
+            } as any,
+          ],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      // validateScript should not be called since testCommand is set
+      expect(mockValidateScript).not.toHaveBeenCalled();
+    });
+
+    it("skips validation when buildCommand is set on package", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: ".",
+              registries: ["npm"],
+              ecosystem: "js",
+              buildCommand: "make build",
+            } as any,
+          ],
+        },
+        options: { skipTests: true, skipBuild: false },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).not.toHaveBeenCalled();
+    });
+
+    it("skips validation when ecosystems.testCommand is set", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          ecosystems: { js: { testCommand: "npx vitest" } },
+          packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).not.toHaveBeenCalled();
+    });
+
+    it("skips validation when ecosystems.buildCommand is set", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          ecosystems: { js: { buildCommand: "npx tsup" } },
+          packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
+        },
+        options: { skipTests: true, skipBuild: false },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).not.toHaveBeenCalled();
+    });
+
+    it("uses pkg.testScript override for validation", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: "packages/a",
+              registries: ["npm"],
+              ecosystem: "js",
+              testScript: "test:special",
+            } as any,
+          ],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("test:special", "test");
+    });
+
+    it("uses ecosystems.testScript override for validation", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          ecosystems: { js: { testScript: "test:ci" } },
+          packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
+        },
+        options: { skipTests: false, skipBuild: true, testScript: "test" },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("test:ci", "test");
+    });
+
+    it("uses pkg.buildScript override for validation", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: "packages/a",
+              registries: ["npm"],
+              ecosystem: "js",
+              buildScript: "build:special",
+            } as any,
+          ],
+        },
+        options: { skipTests: true, skipBuild: false },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("build:special", "build");
+    });
+
+    it("uses ecosystems.buildScript override for validation", async () => {
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          ecosystems: { js: { buildScript: "build:ci" } },
+          packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
+        },
+        options: { skipTests: true, skipBuild: false, buildScript: "build" },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("build:ci", "build");
+    });
+
+    it("validates at root cwd in workspace mode for grouped packages", async () => {
+      const { detectWorkspace } = await import(
+        "../../../src/monorepo/workspace.js"
+      );
+      vi.mocked(detectWorkspace).mockReturnValue([
+        { type: "pnpm", patterns: ["packages/*"] },
+      ] as any);
+
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+            { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+          ],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      // Only called once for the group (groupValidated skips second package)
+      expect(mockValidateScript).toHaveBeenCalledTimes(1);
+    });
+
+    it("validates per-package when package has testScript override in workspace", async () => {
+      const { detectWorkspace } = await import(
+        "../../../src/monorepo/workspace.js"
+      );
+      vi.mocked(detectWorkspace).mockReturnValue([
+        { type: "pnpm", patterns: ["packages/*"] },
+      ] as any);
+
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: "packages/a",
+              registries: ["npm"],
+              ecosystem: "js",
+              testScript: "test:special",
+            } as any,
+          ],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("test:special", "test");
+    });
+
+    it("detects rust workspace via cargo type", async () => {
+      const { detectWorkspace } = await import(
+        "../../../src/monorepo/workspace.js"
+      );
+      vi.mocked(detectWorkspace).mockReturnValue([
+        { type: "cargo", patterns: ["crates/*"] },
+      ] as any);
+
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            { path: "crates/a", registries: ["crates"], ecosystem: "rust" },
+            { path: "crates/b", registries: ["crates"], ecosystem: "rust" },
+          ],
+        },
+        options: { skipTests: false, skipBuild: true },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      // Only called once for the group (workspace groupValidated)
+      expect(mockValidateScript).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips second package for build when groupValidated via test in workspace", async () => {
+      const { detectWorkspace } = await import(
+        "../../../src/monorepo/workspace.js"
+      );
+      vi.mocked(detectWorkspace).mockReturnValue([
+        { type: "pnpm", patterns: ["packages/*"] },
+      ] as any);
+
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+            { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+          ],
+        },
+        options: { skipTests: false, skipBuild: false },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      // test validation runs once for group, sets groupValidated=true
+      // build validation is then skipped for both packages via groupValidated
+      // Total: 1 call (test group)
+      expect(mockValidateScript).toHaveBeenCalledTimes(1);
+    });
+
+    it("validates per-package with buildScript override in workspace", async () => {
+      const { detectWorkspace } = await import(
+        "../../../src/monorepo/workspace.js"
+      );
+      vi.mocked(detectWorkspace).mockReturnValue([
+        { type: "pnpm", patterns: ["packages/*"] },
+      ] as any);
+
+      mockValidateScript.mockResolvedValue(null);
+      const subtasks = await getSubtasks();
+      const scriptsTask = subtasks[1];
+      const ctx = createCtx({
+        config: {
+          packages: [
+            {
+              path: "packages/a",
+              registries: ["npm"],
+              ecosystem: "js",
+              buildScript: "build:special",
+            } as any,
+          ],
+        },
+        options: { skipTests: true, skipBuild: false },
+      });
+
+      await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
+      expect(mockValidateScript).toHaveBeenCalledWith("build:special", "build");
+    });
+  });
+
+  describe("isCI branch", () => {
+    it("uses createCiListrOptions when isCI is true", async () => {
+      vi.doMock("std-env", () => ({ isCI: true }));
+
+      vi.doMock("../../../src/utils/listr.js", () => ({
+        createListr: vi.fn((taskDef: any, options?: any) => {
+          return { _taskDef: taskDef, _options: options, run: vi.fn() };
+        }),
+        createCiListrOptions: vi.fn(() => ({ renderer: "ci" })),
+      }));
+
+      const { requiredConditionsCheckTask } = await import(
+        "../../../src/tasks/required-conditions-check.js"
+      );
+      const result = requiredConditionsCheckTask();
+      expect((result as any)._options).toEqual({ renderer: "ci" });
     });
   });
 

--- a/packages/core/tests/unit/tasks/required-conditions-check.test.ts
+++ b/packages/core/tests/unit/tasks/required-conditions-check.test.ts
@@ -1331,7 +1331,7 @@ describe("requiredConditionsCheckTask", () => {
       expect(mockValidateScript).toHaveBeenCalledTimes(1);
     });
 
-    it("skips second package for build when groupValidated via test in workspace", async () => {
+    it("validates both test and build once each for workspace group", async () => {
       const { detectWorkspace } = await import(
         "../../../src/monorepo/workspace.js"
       );
@@ -1353,10 +1353,10 @@ describe("requiredConditionsCheckTask", () => {
       });
 
       await expect(scriptsTask.task(ctx)).resolves.toBeUndefined();
-      // test validation runs once for group, sets groupValidated=true
-      // build validation is then skipped for both packages via groupValidated
-      // Total: 1 call (test group)
-      expect(mockValidateScript).toHaveBeenCalledTimes(1);
+      // test and build each validated once for workspace group (separate flags)
+      expect(mockValidateScript).toHaveBeenCalledTimes(2);
+      expect(mockValidateScript).toHaveBeenCalledWith("test", "test");
+      expect(mockValidateScript).toHaveBeenCalledWith("build", "build");
     });
 
     it("validates per-package with buildScript override in workspace", async () => {

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -42,6 +42,9 @@ vi.mock("../../../src/changeset/changelog-parser.js", () => ({
 vi.mock("../../../src/manifest/write-versions.js", () => ({
   writeVersionsForEcosystem: vi.fn().mockResolvedValue([]),
 }));
+vi.mock("../../../src/monorepo/workspace.js", () => ({
+  detectWorkspace: vi.fn(() => [{ type: "pnpm", patterns: ["packages/*"] }]),
+}));
 vi.mock("../../../src/ecosystem/catalog.js", () => {
   class MockJsEcosystem {
     packagePath: string;
@@ -51,11 +54,14 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     manifestFiles() {
       return ["package.json"];
     }
-    defaultTestCommand() {
-      return Promise.resolve("pnpm run test");
+    resolveTestCommand(script: string) {
+      return Promise.resolve({ cmd: "pnpm", args: ["run", script] });
     }
-    defaultBuildCommand() {
-      return Promise.resolve("pnpm run build");
+    resolveBuildCommand(script: string) {
+      return Promise.resolve({ cmd: "pnpm", args: ["run", script] });
+    }
+    validateScript() {
+      return Promise.resolve(null);
     }
   }
   class MockRustEcosystem {
@@ -66,11 +72,16 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     manifestFiles() {
       return ["Cargo.toml"];
     }
-    defaultTestCommand() {
-      return Promise.resolve("cargo test");
+    resolveTestCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
     }
-    defaultBuildCommand() {
-      return Promise.resolve("cargo build --release");
+    resolveBuildCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
+    }
+    validateScript() {
+      return Promise.resolve(null);
     }
   }
   const descriptors: Record<string, any> = {
@@ -2026,9 +2037,11 @@ describe("normal pipeline test and build tasks", () => {
     const testTask = tasks[0];
     const task = createTask();
     const ctx: any = {
+      cwd: process.cwd(),
       options: { testScript: "test", mode: "local" as const },
       runtime: { pluginRunner },
       config: {
+        ecosystems: {},
         packages: [
           {
             path: ".",
@@ -2066,9 +2079,11 @@ describe("normal pipeline test and build tasks", () => {
     const buildTask = tasks[1];
     const task = createTask();
     const ctx: any = {
+      cwd: process.cwd(),
       options: { buildScript: "build", mode: "local" as const },
       runtime: { pluginRunner },
       config: {
+        ecosystems: {},
         packages: [
           {
             path: ".",
@@ -2107,6 +2122,7 @@ describe("normal pipeline test and build tasks", () => {
     const testTask = tasks[0];
     const buildTask = tasks[1];
     const ctx: any = {
+      cwd: process.cwd(),
       options: {
         testScript: "test",
         buildScript: "build",
@@ -2114,6 +2130,7 @@ describe("normal pipeline test and build tasks", () => {
       },
       runtime: { pluginRunner },
       config: {
+        ecosystems: {},
         packages: [
           {
             path: ".",

--- a/packages/core/tests/unit/tasks/runner.test.ts
+++ b/packages/core/tests/unit/tasks/runner.test.ts
@@ -24,6 +24,9 @@ vi.mock("../../../src/utils/package-manager.js", () => ({
 vi.mock("../../../src/manifest/write-versions.js", () => ({
   writeVersionsForEcosystem: vi.fn().mockResolvedValue([]),
 }));
+vi.mock("../../../src/monorepo/workspace.js", () => ({
+  detectWorkspace: vi.fn(() => [{ type: "pnpm", patterns: ["packages/*"] }]),
+}));
 vi.mock("../../../src/ecosystem/catalog.js", () => {
   class MockJsEcosystem {
     packagePath: string;
@@ -36,11 +39,14 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     syncLockfile() {
       return Promise.resolve(undefined);
     }
-    defaultTestCommand() {
-      return Promise.resolve("pnpm run test");
+    resolveTestCommand(script: string) {
+      return Promise.resolve({ cmd: "pnpm", args: ["run", script] });
     }
-    defaultBuildCommand() {
-      return Promise.resolve("pnpm run build");
+    resolveBuildCommand(script: string) {
+      return Promise.resolve({ cmd: "pnpm", args: ["run", script] });
+    }
+    validateScript() {
+      return Promise.resolve(null);
     }
   }
   class MockRustEcosystem {
@@ -54,11 +60,16 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
     syncLockfile() {
       return Promise.resolve(undefined);
     }
-    defaultTestCommand() {
-      return Promise.resolve("cargo test");
+    resolveTestCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
     }
-    defaultBuildCommand() {
-      return Promise.resolve("cargo build --release");
+    resolveBuildCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
+    }
+    validateScript() {
+      return Promise.resolve(null);
     }
   }
   const descriptors: Record<string, any> = {
@@ -1117,6 +1128,7 @@ describe("run", () => {
           onStderr: undefined,
           onStdout: undefined,
           throwOnError: true,
+          nodeOptions: { cwd: expect.any(String) },
         });
       } finally {
         Object.defineProperty(process.stdout, "isTTY", {

--- a/packages/core/tests/unit/tasks/test-build.test.ts
+++ b/packages/core/tests/unit/tasks/test-build.test.ts
@@ -748,7 +748,89 @@ describe("build task execution", () => {
       ["-c", "npx vitest"],
       expect.any(Object),
     );
-    // Only one exec for the group
+    // Only one exec for the group (workspace manager handles fan-out)
     expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs ecosystem-level testCommand per-package when no workspace detected", async () => {
+    mockDetectWorkspace.mockReturnValue([]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { testCommand: "npx vitest run" } },
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    // Without a workspace, command must run once per package
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx vitest run"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({
+          cwd: expect.stringContaining("packages/a"),
+        }),
+      }),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx vitest run"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({
+          cwd: expect.stringContaining("packages/b"),
+        }),
+      }),
+    );
+  });
+
+  it("runs ecosystem-level buildCommand per-package when no workspace detected", async () => {
+    mockDetectWorkspace.mockReturnValue([]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { buildCommand: "npx tsup" } },
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    // Without a workspace, command must run once per package
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx tsup"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({
+          cwd: expect.stringContaining("packages/a"),
+        }),
+      }),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx tsup"],
+      expect.objectContaining({
+        nodeOptions: expect.objectContaining({
+          cwd: expect.stringContaining("packages/b"),
+        }),
+      }),
+    );
   });
 });

--- a/packages/core/tests/unit/tasks/test-build.test.ts
+++ b/packages/core/tests/unit/tasks/test-build.test.ts
@@ -1,0 +1,754 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExec = vi.hoisted(() => vi.fn());
+const mockDetectWorkspace = vi.hoisted(() => vi.fn(() => []));
+const mockResolveTestCommand = vi.hoisted(() =>
+  vi.fn((script: string) =>
+    Promise.resolve({ cmd: "pnpm", args: ["run", script] }),
+  ),
+);
+const mockResolveBuildCommand = vi.hoisted(() =>
+  vi.fn((script: string) =>
+    Promise.resolve({ cmd: "pnpm", args: ["run", script] }),
+  ),
+);
+
+vi.mock("../../../src/monorepo/workspace.js", () => ({
+  detectWorkspace: mockDetectWorkspace,
+}));
+
+vi.mock("../../../src/ecosystem/catalog.js", () => {
+  class MockJsEcosystem {
+    packagePath: string;
+    constructor(p: string) {
+      this.packagePath = p;
+    }
+    resolveTestCommand(script: string) {
+      return mockResolveTestCommand(script);
+    }
+    resolveBuildCommand(script: string) {
+      return mockResolveBuildCommand(script);
+    }
+  }
+  class MockRustEcosystem {
+    packagePath: string;
+    constructor(p: string) {
+      this.packagePath = p;
+    }
+    resolveTestCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
+    }
+    resolveBuildCommand(script: string) {
+      const parts = script.split(/\s+/);
+      return Promise.resolve({ cmd: "cargo", args: parts });
+    }
+  }
+  const descriptors: Record<string, any> = {
+    js: {
+      key: "js",
+      label: "JavaScript",
+      ecosystemClass: MockJsEcosystem,
+    },
+    rust: {
+      key: "rust",
+      label: "Rust",
+      ecosystemClass: MockRustEcosystem,
+    },
+  };
+  return {
+    ecosystemCatalog: {
+      get: vi.fn((key: string) => descriptors[key]),
+      all: vi.fn(() => Object.values(descriptors)),
+    },
+  };
+});
+
+vi.mock("../../../src/utils/exec.js", () => ({
+  exec: mockExec,
+}));
+
+vi.mock("../../../src/tasks/runner-utils/output-formatting.js", () => ({
+  shouldRenderLiveCommandOutput: vi.fn(() => false),
+  createLiveCommandOutput: vi.fn(),
+}));
+
+import type { PubmContext } from "../../../src/context.js";
+import { makeTestContext } from "../../helpers/make-context.js";
+
+function createCtx(
+  overrides: {
+    config?: Partial<PubmContext["config"]>;
+    options?: Partial<PubmContext["options"]>;
+    runtime?: Partial<PubmContext["runtime"]>;
+    cwd?: string;
+  } = {},
+): PubmContext {
+  return makeTestContext({
+    config: {
+      packages: [
+        {
+          path: ".",
+          registries: ["npm"],
+          ecosystem: "js",
+        },
+      ],
+      ...overrides.config,
+    },
+    options: {
+      testScript: "test",
+      buildScript: "build",
+      ...overrides.options,
+    },
+    runtime: {
+      version: "1.0.0",
+      promptEnabled: true,
+      cleanWorkingTree: true,
+      ...overrides.runtime,
+    },
+    cwd: overrides.cwd,
+  });
+}
+
+function createTask() {
+  return {
+    title: "",
+    output: "",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExec.mockResolvedValue({ stdout: "", stderr: "" });
+  mockDetectWorkspace.mockReturnValue([]);
+  mockResolveTestCommand.mockImplementation((script: string) =>
+    Promise.resolve({ cmd: "pnpm", args: ["run", script] }),
+  );
+  mockResolveBuildCommand.mockImplementation((script: string) =>
+    Promise.resolve({ cmd: "pnpm", args: ["run", script] }),
+  );
+});
+
+describe("createTestTask", () => {
+  it("is disabled when hasPrepare is false", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createTestTask(false, false);
+    expect(task.enabled).toBe(false);
+  });
+
+  it("is disabled when skipTests is true", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createTestTask(true, true);
+    expect(task.enabled).toBe(false);
+  });
+
+  it("is enabled when hasPrepare is true and skipTests is false", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createTestTask(true, false);
+    expect(task.enabled).toBe(true);
+  });
+});
+
+describe("createBuildTask", () => {
+  it("is disabled when hasPrepare is false", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createBuildTask(false, false);
+    expect(task.enabled).toBe(false);
+  });
+
+  it("is disabled when skipBuild is true", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createBuildTask(true, true);
+    expect(task.enabled).toBe(false);
+  });
+
+  it("is enabled when hasPrepare is true and skipBuild is false", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const task = createBuildTask(true, false);
+    expect(task.enabled).toBe(true);
+  });
+});
+
+describe("test task execution", () => {
+  it("runs test with workspace command via pnpm", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx();
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "pnpm",
+      ["run", "test"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs test with testCommand as sh -c", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+            testCommand: "npm run test -- --ci",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npm run test -- --ci"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs test with ecosystem-level testCommand", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { testCommand: "npx vitest run" } },
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx vitest run"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs test with ecosystem-level testScript", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { testScript: "test:ci" } },
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+          },
+        ],
+      },
+      options: { testScript: undefined },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockResolveTestCommand).toHaveBeenCalledWith("test:ci");
+  });
+
+  it("uses ECOSYSTEM_DEFAULTS when no script is configured", async () => {
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      options: { testScript: undefined },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockResolveTestCommand).toHaveBeenCalledWith("test");
+  });
+
+  it("runs per-package when no workspace detected", async () => {
+    mockDetectWorkspace.mockReturnValue([]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs individual package with testScript override", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          {
+            path: "packages/b",
+            registries: ["npm"],
+            ecosystem: "js",
+            testScript: "test:special",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    // Group run for packages/a + individual run for packages/b
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs individual package with testCommand override", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          {
+            path: "packages/a",
+            registries: ["npm"],
+            ecosystem: "js",
+            testCommand: "make test",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "make test"],
+      expect.any(Object),
+    );
+  });
+
+  it("throws AbstractError when test execution fails", async () => {
+    mockExec.mockRejectedValue(new Error("test failed"));
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx();
+    const task = createTask();
+
+    await expect((testTask as any).task(ctx, task)).rejects.toThrow();
+  });
+
+  it("runs rust ecosystem test with cargo", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "cargo", patterns: ["crates/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
+      },
+      options: { testScript: undefined },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cargo",
+      ["test"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs rust per-package without workspace", async () => {
+    mockDetectWorkspace.mockReturnValue([]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          { path: "crates/a", registries: ["crates"], ecosystem: "rust" },
+        ],
+      },
+      options: { testScript: undefined },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cargo",
+      ["test"],
+      expect.any(Object),
+    );
+  });
+});
+
+describe("build task execution", () => {
+  it("runs build with workspace command", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx();
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "pnpm",
+      ["run", "build"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs build with buildCommand as sh -c", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+            buildCommand: "make build",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "make build"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs build with ecosystem-level buildCommand", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { buildCommand: "npx tsup" } },
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx tsup"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs build with ecosystem-level buildScript", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { buildScript: "build:prod" } },
+        packages: [
+          {
+            path: ".",
+            registries: ["npm"],
+            ecosystem: "js",
+          },
+        ],
+      },
+      options: { buildScript: undefined },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockResolveBuildCommand).toHaveBeenCalledWith("build:prod");
+  });
+
+  it("runs per-package when no workspace detected", async () => {
+    mockDetectWorkspace.mockReturnValue([]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs individual package with buildCommand override", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          {
+            path: "packages/a",
+            registries: ["npm"],
+            ecosystem: "js",
+            buildCommand: "make build",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "make build"],
+      expect.any(Object),
+    );
+  });
+
+  it("runs individual package with buildScript override", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          {
+            path: "packages/a",
+            registries: ["npm"],
+            ecosystem: "js",
+            buildScript: "build:special",
+          },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockResolveBuildCommand).toHaveBeenCalledWith("build:special");
+  });
+
+  it("throws AbstractError when build execution fails", async () => {
+    mockExec.mockRejectedValue(new Error("build failed"));
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx();
+    const task = createTask();
+
+    await expect((buildTask as any).task(ctx, task)).rejects.toThrow();
+  });
+
+  it("runs rust ecosystem build with cargo", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "cargo", patterns: ["crates/*"] },
+    ]);
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [{ path: ".", registries: ["crates"], ecosystem: "rust" }],
+      },
+      options: { buildScript: undefined },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cargo",
+      ["build", "--release"],
+      expect.any(Object),
+    );
+  });
+
+  it("uses ECOSYSTEM_DEFAULTS build for unknown global script", async () => {
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      options: { buildScript: undefined },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockResolveBuildCommand).toHaveBeenCalledWith("build");
+  });
+
+  it("falls back to type name when no ecosystem default exists", async () => {
+    // This tests the ?? type fallback in ECOSYSTEM_DEFAULTS
+    // We can't easily test an unknown ecosystem, but we ensure
+    // the defaults path works for known ecosystems
+    const { createBuildTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const buildTask = createBuildTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [{ path: ".", registries: ["npm"], ecosystem: "js" }],
+      },
+      options: { buildScript: undefined },
+    });
+    const task = createTask();
+
+    await (buildTask as any).task(ctx, task);
+
+    expect(mockResolveBuildCommand).toHaveBeenCalledWith("build");
+  });
+
+  it("handles mixed ecosystem packages in same run", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+      { type: "cargo", patterns: ["crates/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "crates/a", registries: ["crates"], ecosystem: "rust" },
+        ],
+      },
+      options: { testScript: undefined },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    // Should have 2 exec calls: one for js workspace, one for rust workspace
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("group command path uses sh -c for group-level testCommand", async () => {
+    mockDetectWorkspace.mockReturnValue([
+      { type: "pnpm", patterns: ["packages/*"] },
+    ]);
+    const { createTestTask } = await import(
+      "../../../src/tasks/phases/test-build.js"
+    );
+    const testTask = createTestTask(true, false);
+    const ctx = createCtx({
+      config: {
+        ecosystems: { js: { testCommand: "npx vitest" } },
+        packages: [
+          { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+          { path: "packages/b", registries: ["npm"], ecosystem: "js" },
+        ],
+      },
+    });
+    const task = createTask();
+
+    await (testTask as any).task(ctx, task);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "npx vitest"],
+      expect.any(Object),
+    );
+    // Only one exec for the group
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/tests/unit/tasks/test-build.test.ts
+++ b/packages/core/tests/unit/tasks/test-build.test.ts
@@ -778,7 +778,7 @@ describe("build task execution", () => {
       ["-c", "npx vitest run"],
       expect.objectContaining({
         nodeOptions: expect.objectContaining({
-          cwd: expect.stringContaining("packages/a"),
+          cwd: expect.stringMatching(/packages[/\\]a$/),
         }),
       }),
     );
@@ -787,7 +787,7 @@ describe("build task execution", () => {
       ["-c", "npx vitest run"],
       expect.objectContaining({
         nodeOptions: expect.objectContaining({
-          cwd: expect.stringContaining("packages/b"),
+          cwd: expect.stringMatching(/packages[/\\]b$/),
         }),
       }),
     );
@@ -819,7 +819,7 @@ describe("build task execution", () => {
       ["-c", "npx tsup"],
       expect.objectContaining({
         nodeOptions: expect.objectContaining({
-          cwd: expect.stringContaining("packages/a"),
+          cwd: expect.stringMatching(/packages[/\\]a$/),
         }),
       }),
     );
@@ -828,7 +828,7 @@ describe("build task execution", () => {
       ["-c", "npx tsup"],
       expect.objectContaining({
         nodeOptions: expect.objectContaining({
-          cwd: expect.stringContaining("packages/b"),
+          cwd: expect.stringMatching(/packages[/\\]b$/),
         }),
       }),
     );


### PR DESCRIPTION
## Summary
- Add `resolveTestCommand`/`resolveBuildCommand`/`validateScript` to Ecosystem abstract class with JS and Rust implementations
- Add `ecosystems` config key for per-ecosystem `testScript`/`testCommand` overrides
- Add per-package `testScript`/`testCommand`/`buildScript`/`buildCommand` config fields
- Rewrite test-build.ts: group packages by ecosystem, detect workspace per ecosystem, 6-level command resolution priority, execute at workspace root or per-package directory
- Rewrite checkScripts: delegate to `ecosystem.validateScript()` with workspace-aware location
- Swap ecosystem registration order (Rust before JS) for NAPI build dependency ordering
- Full shell command support (`sh -c`) for `testCommand` overrides

## Problem solved
- Pure Rust projects failing with `npm run test` (no `package.json`)
- Mixed ecosystem monorepos (Cargo workspace + JS packages) failing with `ENOENT` on root `package.json`
- JS packages in non-workspace directories now execute test/build per-package instead of at root

## Command resolution priority
1. `packages[].testCommand` — full shell command, runs at package dir
2. `packages[].testScript` — ecosystem resolves, runs at package dir
3. `ecosystems.{key}.testCommand` — full shell command
4. `ecosystems.{key}.testScript` — ecosystem resolves
5. Global `testScript` option (default: `"test"`)
6. Ecosystem default (`"test"` for JS, `"test"` for Rust)

## Test plan
- [x] 2036 tests pass (134 test files)
- [x] Coverage: 95.98% stmts, 90.64% branches, 95.58% funcs, 96.42% lines
- [x] Typecheck passes
- [ ] Manual: run pubm on pure Rust project (complete-checkpoint)
- [ ] Manual: run pubm on mixed JS+Rust project (chkpt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)