### PR TITLE
feat(core): redesign release note generation

### DIFF
--- a/packages/core/src/conventional-commit/git-log.ts
+++ b/packages/core/src/conventional-commit/git-log.ts
@@ -45,8 +45,9 @@ export function findLastReleaseRef(
 export function getCommitsSinceRef(
   cwd: string,
   ref: string | undefined,
+  toRef?: string,
 ): RawCommit[] {
-  const range = ref ? `${ref}..HEAD` : "HEAD";
+  const range = ref ? `${ref}..${toRef ?? "HEAD"}` : (toRef ?? "HEAD");
   const format = `${COMMIT_START_MARKER} %h%n%B%n${COMMIT_FILES_MARKER}`;
 
   const output = execGitRaw(cwd, [

--- a/packages/core/src/i18n/locales/de.json
+++ b/packages/core/src/i18n/locales/de.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "Repository-Metadaten für den Release-Entwurf werden aufgelöst...",
   "task.release.openingDraft": "Release-Entwurf für {tag} wird geöffnet...",
   "task.release.collectedCommits": "{count} Commits für {tag} gesammelt.",
+  "task.release.copiedToClipboard": "Release-Notizen in die Zwischenablage kopiert — in den Release-Text einfügen",
+  "task.release.truncated": "Release-Notizen wurden aufgrund der URL-Längenbeschränkung gekürzt",
   "task.publish.registryLabel": "In {registry} veröffentlichen",
   "task.dryRun.registryLabel": "Dry-run {registry}",
   "output.ciPrepareComplete": "CI-Vorbereitung abgeschlossen. Release-Tags gepusht — CI sollte die Veröffentlichung übernehmen.",

--- a/packages/core/src/i18n/locales/en.json
+++ b/packages/core/src/i18n/locales/en.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "Resolving repository metadata for the release draft...",
   "task.release.openingDraft": "Opening release draft for {tag}...",
   "task.release.collectedCommits": "Collected {count} commits for {tag}.",
+  "task.release.copiedToClipboard": "Release notes copied to clipboard — paste into the release body",
+  "task.release.truncated": "Release notes were truncated due to URL length limit",
   "task.publish.registryLabel": "Publish to {registry}",
   "task.dryRun.registryLabel": "Dry-run {registry}",
   "output.ciPrepareComplete": "CI prepare completed. Release tags pushed — CI should pick up the publish.",

--- a/packages/core/src/i18n/locales/es.json
+++ b/packages/core/src/i18n/locales/es.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "Resolviendo metadatos del repositorio para el borrador de publicación...",
   "task.release.openingDraft": "Abriendo borrador de publicación para {tag}...",
   "task.release.collectedCommits": "{count} commits recopilados para {tag}.",
+  "task.release.copiedToClipboard": "Notas de la versión copiadas al portapapeles — pégalas en el cuerpo del release",
+  "task.release.truncated": "Las notas de la versión fueron truncadas debido al límite de longitud de la URL",
   "task.publish.registryLabel": "Publicar en {registry}",
   "task.dryRun.registryLabel": "Dry-run {registry}",
   "output.ciPrepareComplete": "Preparación de CI completada. Etiquetas de publicación enviadas — CI debería encargarse de la publicación.",

--- a/packages/core/src/i18n/locales/fr.json
+++ b/packages/core/src/i18n/locales/fr.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "Résolution des métadonnées du dépôt pour le brouillon de publication...",
   "task.release.openingDraft": "Ouverture du brouillon de publication pour {tag}...",
   "task.release.collectedCommits": "{count} commits collectés pour {tag}.",
+  "task.release.copiedToClipboard": "Notes de version copiées dans le presse-papiers — collez-les dans le corps de la release",
+  "task.release.truncated": "Les notes de version ont été tronquées en raison de la limite de longueur de l'URL",
   "task.publish.registryLabel": "Publier vers {registry}",
   "task.dryRun.registryLabel": "Dry-run {registry}",
   "output.ciPrepareComplete": "Préparation CI terminée. Tags de publication poussés — CI devrait prendre en charge la publication.",

--- a/packages/core/src/i18n/locales/ko.json
+++ b/packages/core/src/i18n/locales/ko.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "릴리스 초안을 위한 저장소 메타데이터 확인 중...",
   "task.release.openingDraft": "{tag} 릴리스 초안 열기 중...",
   "task.release.collectedCommits": "{tag}에 대한 {count}개 커밋 수집됨.",
+  "task.release.copiedToClipboard": "릴리즈 노트가 클립보드에 복사되었습니다 — 릴리즈 본문에 붙여넣기 하세요",
+  "task.release.truncated": "URL 길이 제한으로 릴리즈 노트가 잘렸습니다",
   "task.publish.registryLabel": "{registry}에 배포",
   "task.dryRun.registryLabel": "{registry} Dry-run",
   "output.ciPrepareComplete": "CI 준비 완료. 릴리스 태그가 푸시되었습니다 — CI가 배포를 처리합니다.",

--- a/packages/core/src/i18n/locales/zh-cn.json
+++ b/packages/core/src/i18n/locales/zh-cn.json
@@ -172,6 +172,8 @@
   "task.release.resolvingMetadata": "正在解析发布草稿的仓库元数据...",
   "task.release.openingDraft": "正在打开 {tag} 的发布草稿...",
   "task.release.collectedCommits": "已为 {tag} 收集 {count} 个提交。",
+  "task.release.copiedToClipboard": "发布说明已复制到剪贴板 — 请粘贴到发布正文中",
+  "task.release.truncated": "由于URL长度限制，发布说明已被截断",
   "task.publish.registryLabel": "发布到 {registry}",
   "task.dryRun.registryLabel": "{registry} Dry-run",
   "output.ciPrepareComplete": "CI 准备完成。发布标签已推送 — CI 应处理发布。",

--- a/packages/core/src/tasks/github-release.ts
+++ b/packages/core/src/tasks/github-release.ts
@@ -18,28 +18,6 @@ class GitHubReleaseError extends AbstractError {
 }
 
 /**
- * Format release notes from commits
- */
-function formatReleaseNotes(
-  commits: { id: string; message: string }[],
-  repositoryUrl: string,
-  previousTag: string,
-  latestTag: string,
-): string {
-  const lines = commits.map(
-    ({ id, message }) =>
-      `- ${message.replace(/#(\d+)/g, `[#$1](${repositoryUrl}/issues/$1)`)} ([${id.slice(0, 7)}](${repositoryUrl}/commit/${id}))`,
-  );
-
-  lines.push("");
-  lines.push(
-    `**Full Changelog**: ${repositoryUrl}/compare/${previousTag}...${latestTag}`,
-  );
-
-  return lines.join("\n");
-}
-
-/**
  * Create a GitHub Release using the GitHub REST API
  */
 export async function createGitHubRelease(
@@ -48,7 +26,7 @@ export async function createGitHubRelease(
     displayLabel: string;
     version: string;
     tag: string;
-    changelogBody?: string;
+    body: string;
     assets: PreparedAsset[];
     draft?: boolean;
   },
@@ -61,23 +39,7 @@ export async function createGitHubRelease(
   const git = new Git();
 
   const remoteUrl = await git.repository();
-  const repositoryUrl = remoteUrl
-    .replace(/^git@github\.com:/, "https://github.com/")
-    .replace(/\.git$/, "");
   const { owner, repo } = parseOwnerRepo(remoteUrl);
-
-  // Get tags
-  const previousTag =
-    (await git.previousTag(options.tag)) || (await git.firstCommit());
-
-  // Use changelog content if provided, otherwise build from commits
-  let body: string;
-  if (options.changelogBody) {
-    body = options.changelogBody;
-  } else {
-    const commits = (await git.commits(previousTag, options.tag)).slice(1);
-    body = formatReleaseNotes(commits, repositoryUrl, previousTag, options.tag);
-  }
 
   // Create the release via GitHub API
   const createResponse = await fetch(
@@ -92,7 +54,7 @@ export async function createGitHubRelease(
       body: JSON.stringify({
         tag_name: options.tag,
         name: options.tag,
-        body,
+        body: options.body,
         draft: !!options.draft,
         prerelease: !!prerelease(options.version),
       }),

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -325,12 +325,14 @@ export function createReleaseTask(
             task.title += ` ${linkUrl}`;
 
             if (first) {
+              const openingMsg = t("task.release.openingDraft", { tag });
               if (truncated.clipboardCopied) {
-                task.output = t("task.release.copiedToClipboard");
+                task.output = `${t("task.release.copiedToClipboard")}\n${openingMsg}`;
               } else if (truncated.truncated) {
-                task.output = t("task.release.truncated");
+                task.output = `${t("task.release.truncated")}\n${openingMsg}`;
+              } else {
+                task.output = openingMsg;
               }
-              task.output = t("task.release.openingDraft", { tag });
               await openUrl(releaseDraftUrl.toString());
               first = false;
             }
@@ -374,12 +376,14 @@ export function createReleaseTask(
 
           const linkUrl = ui.link("Link", releaseDraftUrl.toString());
           task.title += ` ${linkUrl}`;
+          const openingMsg = t("task.release.openingDraft", { tag });
           if (truncated.clipboardCopied) {
-            task.output = t("task.release.copiedToClipboard");
+            task.output = `${t("task.release.copiedToClipboard")}\n${openingMsg}`;
           } else if (truncated.truncated) {
-            task.output = t("task.release.truncated");
+            task.output = `${t("task.release.truncated")}\n${openingMsg}`;
+          } else {
+            task.output = openingMsg;
           }
-          task.output = t("task.release.openingDraft", { tag });
           await openUrl(releaseDraftUrl.toString());
         }
       }

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -13,7 +13,11 @@ import {
 import { openUrl } from "../../utils/open-url.js";
 import { ui } from "../../utils/ui.js";
 import { createGitHubRelease, deleteGitHubRelease } from "../github-release.js";
-import { buildReleaseBody, buildFixedReleaseBody, truncateForUrl } from "../release-notes.js";
+import {
+  buildFixedReleaseBody,
+  buildReleaseBody,
+  truncateForUrl,
+} from "../release-notes.js";
 import { prepareReleaseAssets } from "../runner-utils/manifest-handling.js";
 import { formatVersionSummary } from "../runner-utils/output-formatting.js";
 import {
@@ -211,11 +215,13 @@ export function createReleaseTask(
           let body: string;
           if (plan.mode === "fixed") {
             body = await buildFixedReleaseBody(ctx, {
-              packages: [...plan.packages.entries()].map(([pkgPath, pkgVersion]) => ({
-                pkgPath,
-                pkgName: getPackageName(ctx, pkgPath),
-                version: pkgVersion,
-              })),
+              packages: [...plan.packages.entries()].map(
+                ([pkgPath, pkgVersion]) => ({
+                  pkgPath,
+                  pkgName: getPackageName(ctx, pkgPath),
+                  version: pkgVersion,
+                }),
+              ),
               tag,
               repositoryUrl,
             });
@@ -336,11 +342,13 @@ export function createReleaseTask(
           let body: string;
           if (plan.mode === "fixed") {
             body = await buildFixedReleaseBody(ctx, {
-              packages: [...plan.packages.entries()].map(([pkgPath, pkgVersion]) => ({
-                pkgPath,
-                pkgName: getPackageName(ctx, pkgPath),
-                version: pkgVersion,
-              })),
+              packages: [...plan.packages.entries()].map(
+                ([pkgPath, pkgVersion]) => ({
+                  pkgPath,
+                  pkgName: getPackageName(ctx, pkgPath),
+                  version: pkgVersion,
+                }),
+              ),
               tag,
               repositoryUrl,
             });

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -1,10 +1,8 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { rmSync } from "node:fs";
 import process from "node:process";
 import { ListrEnquirerPromptAdapter } from "@listr2/prompt-adapter-enquirer";
 import type { ListrTask } from "listr2";
 import SemVer from "semver";
-import { parseChangelogSection } from "../../changeset/changelog-parser.js";
 import type { PubmContext } from "../../context.js";
 import { Git } from "../../git.js";
 import { t } from "../../i18n/index.js";
@@ -15,6 +13,7 @@ import {
 import { openUrl } from "../../utils/open-url.js";
 import { ui } from "../../utils/ui.js";
 import { createGitHubRelease, deleteGitHubRelease } from "../github-release.js";
+import { buildReleaseBody, buildFixedReleaseBody } from "../release-notes.js";
 import { prepareReleaseAssets } from "../runner-utils/manifest-handling.js";
 import { formatVersionSummary } from "../runner-utils/output-formatting.js";
 import {
@@ -141,24 +140,17 @@ export function createReleaseTask(
             const tag = `${pkgName}@${pkgVersion}`;
             task.output = t("task.release.creating", { tag });
 
-            let changelogBody: string | undefined;
-            const pkgConfig = ctx.config.packages.find(
-              (p) => p.path === pkgPath,
-            );
-            if (pkgConfig) {
-              const changelogPath = join(
-                ctx.cwd,
-                pkgConfig.path,
-                "CHANGELOG.md",
-              );
-              if (existsSync(changelogPath)) {
-                const section = parseChangelogSection(
-                  readFileSync(changelogPath, "utf-8"),
-                  pkgVersion,
-                );
-                if (section) changelogBody = section;
-              }
-            }
+            const git = new Git();
+            const repositoryUrl = (await git.repository())
+              .replace(/^git@github\.com:/, "https://github.com/")
+              .replace(/\.git$/, "");
+
+            const body = await buildReleaseBody(ctx, {
+              pkgPath,
+              version: pkgVersion,
+              tag,
+              repositoryUrl,
+            });
 
             const { assets: preparedAssets, tempDir } =
               await prepareReleaseAssets(ctx, pkgName, pkgVersion, pkgPath);
@@ -166,7 +158,7 @@ export function createReleaseTask(
               displayLabel: pkgName,
               version: pkgVersion,
               tag,
-              changelogBody,
+              body,
               assets: preparedAssets,
               draft: !!ctx.options.releaseDraft,
             });
@@ -211,42 +203,29 @@ export function createReleaseTask(
           const tag = `v${version}`;
           task.output = t("task.release.creating", { tag });
 
-          let changelogBody: string | undefined;
+          const git = new Git();
+          const repositoryUrl = (await git.repository())
+            .replace(/^git@github\.com:/, "https://github.com/")
+            .replace(/\.git$/, "");
+
+          let body: string;
           if (plan.mode === "fixed") {
-            const sections: string[] = [];
-            for (const [pkgPath, pkgVersion] of plan.packages) {
-              const pkgName = getPackageName(ctx, pkgPath);
-              const pkgConfig = ctx.config.packages.find(
-                (p) => p.path === pkgPath,
-              );
-              if (!pkgConfig) continue;
-              const changelogPath = join(
-                ctx.cwd,
-                pkgConfig.path,
-                "CHANGELOG.md",
-              );
-              if (existsSync(changelogPath)) {
-                const section = parseChangelogSection(
-                  readFileSync(changelogPath, "utf-8"),
-                  pkgVersion,
-                );
-                if (section) {
-                  sections.push(`## ${pkgName} v${pkgVersion}\n\n${section}`);
-                }
-              }
-            }
-            if (sections.length > 0) {
-              changelogBody = sections.join("\n\n---\n\n");
-            }
+            body = await buildFixedReleaseBody(ctx, {
+              packages: [...plan.packages.entries()].map(([pkgPath, pkgVersion]) => ({
+                pkgPath,
+                pkgName: getPackageName(ctx, pkgPath),
+                version: pkgVersion,
+              })),
+              tag,
+              repositoryUrl,
+            });
           } else {
-            const changelogPath = join(ctx.cwd, "CHANGELOG.md");
-            if (existsSync(changelogPath)) {
-              const section = parseChangelogSection(
-                readFileSync(changelogPath, "utf-8"),
-                version,
-              );
-              if (section) changelogBody = section;
-            }
+            body = await buildReleaseBody(ctx, {
+              pkgPath: plan.packagePath,
+              version,
+              tag,
+              repositoryUrl,
+            });
           }
 
           const packageName =
@@ -263,7 +242,7 @@ export function createReleaseTask(
             displayLabel: packageName,
             version,
             tag,
-            changelogBody,
+            body,
             assets: preparedAssets,
             draft: !!ctx.options.releaseDraft,
           });

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -13,7 +13,7 @@ import {
 import { openUrl } from "../../utils/open-url.js";
 import { ui } from "../../utils/ui.js";
 import { createGitHubRelease, deleteGitHubRelease } from "../github-release.js";
-import { buildReleaseBody, buildFixedReleaseBody } from "../release-notes.js";
+import { buildReleaseBody, buildFixedReleaseBody, truncateForUrl } from "../release-notes.js";
 import { prepareReleaseAssets } from "../runner-utils/manifest-handling.js";
 import { formatVersionSummary } from "../runner-utils/output-formatting.js";
 import {
@@ -296,30 +296,34 @@ export function createReleaseTask(
             if (isReleaseExcluded(ctx.config, pkgPath)) continue;
             const pkgName = getPackageName(ctx, pkgPath);
             const tag = `${pkgName}@${pkgVersion}`;
-            const lastRev =
-              (await git.previousTag(tag)) || (await git.firstCommit());
-            const commits = (await git.commits(lastRev, tag)).slice(1);
 
-            let body = commits
-              .map(
-                ({ id, message }) =>
-                  `- ${message.replace(/#/g, `${repositoryUrl}/issues/`)} ${repositoryUrl}/commit/${id}`,
-              )
-              .join("\n");
-            body += `\n\n${repositoryUrl}/compare/${lastRev}...${tag}`;
+            const body = await buildReleaseBody(ctx, {
+              pkgPath,
+              version: pkgVersion,
+              tag,
+              repositoryUrl,
+            });
 
             const releaseDraftUrl = new URL(`${repositoryUrl}/releases/new`);
             releaseDraftUrl.searchParams.set("tag", tag);
-            releaseDraftUrl.searchParams.set("body", body);
             releaseDraftUrl.searchParams.set(
               "prerelease",
               `${!!prerelease(pkgVersion)}`,
             );
 
+            const baseUrl = `${releaseDraftUrl.toString()}&body=`;
+            const truncated = await truncateForUrl(body, baseUrl);
+            releaseDraftUrl.searchParams.set("body", truncated.body);
+
             const linkUrl = ui.link(tag, releaseDraftUrl.toString());
             task.title += ` ${linkUrl}`;
 
             if (first) {
+              if (truncated.clipboardCopied) {
+                task.output = t("task.release.copiedToClipboard");
+              } else if (truncated.truncated) {
+                task.output = t("task.release.truncated");
+              }
               task.output = t("task.release.openingDraft", { tag });
               await openUrl(releaseDraftUrl.toString());
               first = false;
@@ -328,32 +332,45 @@ export function createReleaseTask(
         } else {
           const version = plan.version;
           const tag = `v${version}`;
-          const lastRev =
-            (await git.previousTag(tag)) || (await git.firstCommit());
-          const commits = (await git.commits(lastRev, tag)).slice(1);
-          task.output = t("task.release.collectedCommits", {
-            count: commits.length,
-            tag,
-          });
 
-          let body = commits
-            .map(
-              ({ id, message }) =>
-                `- ${message.replace(/#/g, `${repositoryUrl}/issues/`)} ${repositoryUrl}/commit/${id}`,
-            )
-            .join("\n");
-          body += `\n\n${repositoryUrl}/compare/${lastRev}...${tag}`;
+          let body: string;
+          if (plan.mode === "fixed") {
+            body = await buildFixedReleaseBody(ctx, {
+              packages: [...plan.packages.entries()].map(([pkgPath, pkgVersion]) => ({
+                pkgPath,
+                pkgName: getPackageName(ctx, pkgPath),
+                version: pkgVersion,
+              })),
+              tag,
+              repositoryUrl,
+            });
+          } else {
+            body = await buildReleaseBody(ctx, {
+              pkgPath: plan.mode === "single" ? plan.packagePath : undefined,
+              version,
+              tag,
+              repositoryUrl,
+            });
+          }
 
           const releaseDraftUrl = new URL(`${repositoryUrl}/releases/new`);
           releaseDraftUrl.searchParams.set("tag", tag);
-          releaseDraftUrl.searchParams.set("body", body);
           releaseDraftUrl.searchParams.set(
             "prerelease",
             `${!!prerelease(version)}`,
           );
 
+          const baseUrl = `${releaseDraftUrl.toString()}&body=`;
+          const truncated = await truncateForUrl(body, baseUrl);
+          releaseDraftUrl.searchParams.set("body", truncated.body);
+
           const linkUrl = ui.link("Link", releaseDraftUrl.toString());
           task.title += ` ${linkUrl}`;
+          if (truncated.clipboardCopied) {
+            task.output = t("task.release.copiedToClipboard");
+          } else if (truncated.truncated) {
+            task.output = t("task.release.truncated");
+          }
           task.output = t("task.release.openingDraft", { tag });
           await openUrl(releaseDraftUrl.toString());
         }

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -1,0 +1,18 @@
+import type { ChangelogSection } from "../changelog/types.js";
+
+export function renderReleaseNoteSections(
+  sections: ChangelogSection[],
+): string {
+  if (sections.length === 0) return "";
+
+  const parts: string[] = [];
+  for (const section of sections) {
+    if (section.category) {
+      parts.push(`### ${section.category}\n\n${section.items.join("\n")}`);
+    } else {
+      parts.push(section.items.join("\n"));
+    }
+  }
+
+  return parts.join("\n\n");
+}

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -103,6 +103,38 @@ export async function buildReleaseBody(
   return appendCompareLink ? `${body}\n\n${compareLink}` : body;
 }
 
+export async function buildFixedReleaseBody(
+  ctx: PubmContext,
+  options: {
+    packages: Array<{ pkgPath: string; pkgName: string; version: string }>;
+    tag: string;
+    repositoryUrl: string;
+  },
+): Promise<string> {
+  const { packages, tag, repositoryUrl } = options;
+
+  // Resolve previousTag once and pass it down to avoid redundant git calls per package
+  const git = new Git();
+  const previousTag = (await git.previousTag(tag)) || (await git.firstCommit());
+
+  const sections: string[] = [];
+  for (const pkg of packages) {
+    const body = await buildReleaseBody(ctx, {
+      pkgPath: pkg.pkgPath,
+      version: pkg.version,
+      tag,
+      repositoryUrl,
+      appendCompareLink: false,
+      previousTag,
+    });
+
+    sections.push(`## ${pkg.pkgName} v${pkg.version}\n\n${body}`);
+  }
+
+  const joined = sections.join("\n\n---\n\n");
+  return `${joined}\n\n**Full Changelog**: ${repositoryUrl}/compare/${previousTag}...${tag}`;
+}
+
 function extractChangelog(
   ctx: PubmContext,
   pkgPath: string | undefined,

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -1,15 +1,15 @@
-import { existsSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { copyToClipboard } from "../utils/clipboard.js";
 import { ConventionalCommitChangelogWriter } from "../changelog/conventional-commit-writer.js";
+import type { ChangelogSection } from "../changelog/types.js";
 import { parseChangelogSection } from "../changeset/changelog-parser.js";
+import type { PubmContext } from "../context.js";
+import type { RawCommit } from "../conventional-commit/git-log.js";
 import { parseConventionalCommit } from "../conventional-commit/parser.js";
 import { resolveCommitPackages } from "../conventional-commit/scope-resolver.js";
-import type { RawCommit } from "../conventional-commit/git-log.js";
-import type { PubmContext } from "../context.js";
 import { Git } from "../git.js";
-import type { ChangelogSection } from "../changelog/types.js";
+import { copyToClipboard } from "../utils/clipboard.js";
 
 export function renderReleaseNoteSections(
   sections: ChangelogSection[],
@@ -147,10 +147,7 @@ function extractChangelog(
 
   if (!existsSync(changelogPath)) return null;
 
-  return parseChangelogSection(
-    readFileSync(changelogPath, "utf-8"),
-    version,
-  );
+  return parseChangelogSection(readFileSync(changelogPath, "utf-8"), version);
 }
 
 const MAX_URL_LENGTH = 8000;
@@ -177,9 +174,7 @@ export async function truncateForUrl(
     : "\n\n... (truncated)";
 
   const availableLength =
-    MAX_URL_LENGTH -
-    baseUrl.length -
-    encodeURIComponent(suffix).length;
+    MAX_URL_LENGTH - baseUrl.length - encodeURIComponent(suffix).length;
 
   let lo = 0;
   let hi = body.length;

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -1,11 +1,10 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ConventionalCommitChangelogWriter } from "../changelog/conventional-commit-writer.js";
 import type { ChangelogSection } from "../changelog/types.js";
 import { parseChangelogSection } from "../changeset/changelog-parser.js";
 import type { PubmContext } from "../context.js";
-import type { RawCommit } from "../conventional-commit/git-log.js";
+import { getCommitsSinceRef } from "../conventional-commit/git-log.js";
 import { parseConventionalCommit } from "../conventional-commit/parser.js";
 import { resolveCommitPackages } from "../conventional-commit/scope-resolver.js";
 import { Git } from "../git.js";
@@ -59,15 +58,15 @@ export async function buildReleaseBody(
   }
 
   // Priority 2 & 3: Commits
-  // Use git.commits for the raw list; the first entry is the boundary commit itself, so slice(1)
-  const commits = (await git.commits(previousTag, tag)).slice(1);
+  // git.commits uses the triple-dot range which already excludes the boundary commit (previousTag)
+  const commits = await git.commits(previousTag, tag);
   if (commits.length === 0) {
     return appendCompareLink ? compareLink : "";
   }
 
   // Parse as conventional commits with file paths (needed for scope resolution in monorepos)
   // Use bounded range (previousTag..tag) to avoid including commits past the tag
-  const rawCommits = getCommitsBetweenRefs(ctx.cwd, previousTag, tag);
+  const rawCommits = getCommitsSinceRef(ctx.cwd, previousTag, tag);
   const parsed = rawCommits
     .map((c) => parseConventionalCommit(c.hash, c.message, c.files))
     .filter((c): c is NonNullable<typeof c> => c !== null);
@@ -192,69 +191,4 @@ export async function truncateForUrl(
     truncated: true,
     clipboardCopied,
   };
-}
-
-/**
- * Get commits with file paths between two refs (bounded range).
- * Uses previousTag..tag to avoid including commits past the tag.
- */
-function getCommitsBetweenRefs(
-  cwd: string,
-  fromRef: string,
-  toRef: string,
-): RawCommit[] {
-  try {
-    const output = execFileSync(
-      "git",
-      [
-        "log",
-        `${fromRef}..${toRef}`,
-        "--format=COMMIT_START %h%n%B%nCOMMIT_FILES",
-        "--name-only",
-      ],
-      { cwd, encoding: "utf-8" },
-    );
-
-    if (!output.trim()) return [];
-
-    const commits: RawCommit[] = [];
-    const lines = output.split("\n");
-    let i = 0;
-
-    while (i < lines.length) {
-      if (!lines[i].startsWith("COMMIT_START")) {
-        i++;
-        continue;
-      }
-
-      const hash = lines[i].slice("COMMIT_START ".length).trim();
-      i++;
-
-      const messageLines: string[] = [];
-      while (
-        i < lines.length &&
-        !lines[i].startsWith("COMMIT_FILES") &&
-        !lines[i].startsWith("COMMIT_START")
-      ) {
-        messageLines.push(lines[i]);
-        i++;
-      }
-
-      if (i < lines.length && lines[i].startsWith("COMMIT_FILES")) i++;
-
-      const files: string[] = [];
-      while (i < lines.length && !lines[i].startsWith("COMMIT_START")) {
-        const file = lines[i].trim();
-        if (file) files.push(file);
-        i++;
-      }
-
-      const message = messageLines.join("\n").trim();
-      if (hash && message) commits.push({ hash, message, files });
-    }
-
-    return commits;
-  } catch {
-    return [];
-  }
 }

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -1,3 +1,13 @@
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { ConventionalCommitChangelogWriter } from "../changelog/conventional-commit-writer.js";
+import { parseChangelogSection } from "../changeset/changelog-parser.js";
+import { parseConventionalCommit } from "../conventional-commit/parser.js";
+import { resolveCommitPackages } from "../conventional-commit/scope-resolver.js";
+import type { RawCommit } from "../conventional-commit/git-log.js";
+import type { PubmContext } from "../context.js";
+import { Git } from "../git.js";
 import type { ChangelogSection } from "../changelog/types.js";
 
 export function renderReleaseNoteSections(
@@ -15,4 +25,162 @@ export function renderReleaseNoteSections(
   }
 
   return parts.join("\n\n");
+}
+
+export async function buildReleaseBody(
+  ctx: PubmContext,
+  options: {
+    pkgPath?: string;
+    version: string;
+    tag: string;
+    repositoryUrl: string;
+    appendCompareLink?: boolean;
+    /** Pre-resolved previousTag to avoid redundant git calls (used by buildFixedReleaseBody) */
+    previousTag?: string;
+  },
+): Promise<string> {
+  const { pkgPath, version, tag, repositoryUrl } = options;
+  const appendCompareLink = options.appendCompareLink ?? true;
+
+  const git = new Git();
+  const previousTag =
+    options.previousTag ??
+    ((await git.previousTag(tag)) || (await git.firstCommit()));
+
+  const compareLink = `**Full Changelog**: ${repositoryUrl}/compare/${previousTag}...${tag}`;
+
+  // Priority 1: CHANGELOG.md
+  const changelogBody = extractChangelog(ctx, pkgPath, version);
+  if (changelogBody) {
+    return appendCompareLink
+      ? `${changelogBody}\n\n${compareLink}`
+      : changelogBody;
+  }
+
+  // Priority 2 & 3: Commits
+  // Use git.commits for the raw list; the first entry is the boundary commit itself, so slice(1)
+  const commits = (await git.commits(previousTag, tag)).slice(1);
+  if (commits.length === 0) {
+    return appendCompareLink ? compareLink : "";
+  }
+
+  // Parse as conventional commits with file paths (needed for scope resolution in monorepos)
+  // Use bounded range (previousTag..tag) to avoid including commits past the tag
+  const rawCommits = getCommitsBetweenRefs(ctx.cwd, previousTag, tag);
+  const parsed = rawCommits
+    .map((c) => parseConventionalCommit(c.hash, c.message, c.files))
+    .filter((c): c is NonNullable<typeof c> => c !== null);
+
+  // Filter by package scope in monorepo independent mode
+  const filtered = pkgPath
+    ? parsed.filter((c) => {
+        const packages = resolveCommitPackages(c, [pkgPath]);
+        return packages.length > 0;
+      })
+    : parsed;
+
+  if (filtered.length > 0) {
+    // Map to VersionEntry for the writer
+    const entries = filtered.map((c) => ({
+      summary: c.description,
+      type: c.type,
+      hash: c.hash.slice(0, 7),
+    }));
+
+    const writer = new ConventionalCommitChangelogWriter();
+    const sections = writer.formatEntries(entries);
+    const body = renderReleaseNoteSections(sections);
+
+    return appendCompareLink ? `${body}\n\n${compareLink}` : body;
+  }
+
+  // Priority 3: Raw commit list (no conventional commits found, or none matched this package)
+  const lines = commits.map(
+    ({ id, message }) => `- ${message} (${id.slice(0, 7)})`,
+  );
+  const body = lines.join("\n");
+
+  return appendCompareLink ? `${body}\n\n${compareLink}` : body;
+}
+
+function extractChangelog(
+  ctx: PubmContext,
+  pkgPath: string | undefined,
+  version: string,
+): string | null {
+  const changelogPath = pkgPath
+    ? join(ctx.cwd, pkgPath, "CHANGELOG.md")
+    : join(ctx.cwd, "CHANGELOG.md");
+
+  if (!existsSync(changelogPath)) return null;
+
+  return parseChangelogSection(
+    readFileSync(changelogPath, "utf-8"),
+    version,
+  );
+}
+
+/**
+ * Get commits with file paths between two refs (bounded range).
+ * Uses previousTag..tag to avoid including commits past the tag.
+ */
+function getCommitsBetweenRefs(
+  cwd: string,
+  fromRef: string,
+  toRef: string,
+): RawCommit[] {
+  try {
+    const output = execFileSync(
+      "git",
+      [
+        "log",
+        `${fromRef}..${toRef}`,
+        "--format=COMMIT_START %h%n%B%nCOMMIT_FILES",
+        "--name-only",
+      ],
+      { cwd, encoding: "utf-8" },
+    );
+
+    if (!output.trim()) return [];
+
+    const commits: RawCommit[] = [];
+    const lines = output.split("\n");
+    let i = 0;
+
+    while (i < lines.length) {
+      if (!lines[i].startsWith("COMMIT_START")) {
+        i++;
+        continue;
+      }
+
+      const hash = lines[i].slice("COMMIT_START ".length).trim();
+      i++;
+
+      const messageLines: string[] = [];
+      while (
+        i < lines.length &&
+        !lines[i].startsWith("COMMIT_FILES") &&
+        !lines[i].startsWith("COMMIT_START")
+      ) {
+        messageLines.push(lines[i]);
+        i++;
+      }
+
+      if (i < lines.length && lines[i].startsWith("COMMIT_FILES")) i++;
+
+      const files: string[] = [];
+      while (i < lines.length && !lines[i].startsWith("COMMIT_START")) {
+        const file = lines[i].trim();
+        if (file) files.push(file);
+        i++;
+      }
+
+      const message = messageLines.join("\n").trim();
+      if (hash && message) commits.push({ hash, message, files });
+    }
+
+    return commits;
+  } catch {
+    return [];
+  }
 }

--- a/packages/core/src/tasks/release-notes.ts
+++ b/packages/core/src/tasks/release-notes.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
+import { copyToClipboard } from "../utils/clipboard.js";
 import { ConventionalCommitChangelogWriter } from "../changelog/conventional-commit-writer.js";
 import { parseChangelogSection } from "../changeset/changelog-parser.js";
 import { parseConventionalCommit } from "../conventional-commit/parser.js";
@@ -150,6 +151,52 @@ function extractChangelog(
     readFileSync(changelogPath, "utf-8"),
     version,
   );
+}
+
+const MAX_URL_LENGTH = 8000;
+
+export interface TruncateResult {
+  body: string;
+  truncated: boolean;
+  clipboardCopied: boolean;
+}
+
+export async function truncateForUrl(
+  body: string,
+  baseUrl: string,
+): Promise<TruncateResult> {
+  const testUrl = `${baseUrl}${encodeURIComponent(body)}`;
+  if (testUrl.length <= MAX_URL_LENGTH) {
+    return { body, truncated: false, clipboardCopied: false };
+  }
+
+  const clipboardCopied = await copyToClipboard(body);
+
+  const suffix = clipboardCopied
+    ? "\n\n... (truncated, full notes copied to clipboard)"
+    : "\n\n... (truncated)";
+
+  const availableLength =
+    MAX_URL_LENGTH -
+    baseUrl.length -
+    encodeURIComponent(suffix).length;
+
+  let lo = 0;
+  let hi = body.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (encodeURIComponent(body.slice(0, mid)).length <= availableLength) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return {
+    body: body.slice(0, lo) + suffix,
+    truncated: true,
+    clipboardCopied,
+  };
 }
 
 /**

--- a/packages/core/src/utils/clipboard.ts
+++ b/packages/core/src/utils/clipboard.ts
@@ -1,0 +1,34 @@
+import process from "node:process";
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  const commands = getClipboardCommands();
+
+  for (const cmd of commands) {
+    try {
+      const proc = Bun.spawn(cmd, {
+        stdin: "pipe",
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      proc.stdin.write(text);
+      proc.stdin.end();
+      const exitCode = await proc.exited;
+      if (exitCode === 0) return true;
+    } catch {
+      // Command not found or spawn failure, try next
+    }
+  }
+
+  return false;
+}
+
+function getClipboardCommands(): string[][] {
+  switch (process.platform) {
+    case "darwin":
+      return [["pbcopy"]];
+    case "win32":
+      return [["clip"]];
+    default:
+      return [["xclip", "-selection", "clipboard"], ["wl-copy"]];
+  }
+}

--- a/packages/core/tests/unit/tasks/github-release.test.ts
+++ b/packages/core/tests/unit/tasks/github-release.test.ts
@@ -45,15 +45,16 @@ describe("createGitHubRelease", () => {
 
     await expect(
       createGitHubRelease({} as any, {
-        packageName: "pubm",
+        displayLabel: "pubm",
         version: "1.0.0",
         tag: "v1.0.0",
+        body: "",
         assets: [],
       }),
     ).rejects.toThrow(/GITHUB_TOKEN environment variable is required/);
   });
 
-  it("builds release notes from commits when no changelog body is provided", async () => {
+  it("uses the provided body directly", async () => {
     const { createGitHubRelease } = await freshImport();
     const { mockReadFileSync, mockGit } = await getMocks();
 
@@ -63,19 +64,13 @@ describe("createGitHubRelease", () => {
         repository: vi
           .fn()
           .mockResolvedValue("https://github.com/pubm/pubm.git"),
-        latestTag: vi.fn().mockResolvedValue("v1.2.0"),
-        previousTag: vi.fn().mockResolvedValue(null),
-        firstCommit: vi.fn().mockResolvedValue("first-commit"),
-        commits: vi.fn().mockResolvedValue([
-          { id: "ignored", message: "ignored" },
-          { id: "abcdef1234567", message: "feat: fix #42" },
-        ]),
       } as any;
     } as any);
 
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
+        id: 1,
         html_url: "https://github.com/pubm/pubm/releases/tag/v1.2.0",
         upload_url:
           "https://uploads.github.com/repos/pubm/pubm/releases/1/assets{?name,label}",
@@ -89,8 +84,9 @@ describe("createGitHubRelease", () => {
         displayLabel: "pubm",
         version: "1.2.0",
         tag: "v1.2.0",
+        body: "### Features\n\n- fix #42 (abcdef1)",
         assets: [],
-      } as any,
+      },
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -98,12 +94,7 @@ describe("createGitHubRelease", () => {
     expect(payload.tag_name).toBe("v1.2.0");
     expect(payload.name).toBe("v1.2.0");
     expect(payload.prerelease).toBe(false);
-    expect(payload.body).toContain(
-      "[#42](https://github.com/pubm/pubm/issues/42)",
-    );
-    expect(payload.body).toContain(
-      "https://github.com/pubm/pubm/compare/first-commit...v1.2.0",
-    );
+    expect(payload.body).toBe("### Features\n\n- fix #42 (abcdef1)");
     expect(result?.assets).toEqual([]);
     expect(result?.displayLabel).toBe("pubm");
   });
@@ -115,16 +106,13 @@ describe("createGitHubRelease", () => {
     mockGit.mockImplementation(function () {
       return {
         repository: vi.fn().mockResolvedValue("git@github.com:pubm/pubm.git"),
-        latestTag: vi.fn().mockResolvedValue("v2.0.0-beta.1"),
-        previousTag: vi.fn().mockResolvedValue("v1.9.0"),
-        firstCommit: vi.fn().mockResolvedValue("first-commit"),
-        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
 
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
+        id: 2,
         html_url: "https://github.com/pubm/pubm/releases/tag/v2.0.0-beta.1",
         upload_url:
           "https://uploads.github.com/repos/pubm/pubm/releases/2/assets{?name,label}",
@@ -133,10 +121,10 @@ describe("createGitHubRelease", () => {
     global.fetch = fetchMock as any;
 
     const result = await createGitHubRelease({} as any, {
-      packageName: "pubm",
+      displayLabel: "pubm",
       version: "2.0.0-beta.1",
       tag: "v2.0.0-beta.1",
-      changelogBody: "Release notes from CHANGELOG",
+      body: "Release notes from CHANGELOG",
       assets: [],
     });
 
@@ -156,10 +144,6 @@ describe("createGitHubRelease", () => {
     mockGit.mockImplementation(function () {
       return {
         repository: vi.fn().mockResolvedValue("git@github.com:pubm/pubm.git"),
-        latestTag: vi.fn().mockResolvedValue("v2.0.0-beta.1"),
-        previousTag: vi.fn().mockResolvedValue("v1.9.0"),
-        firstCommit: vi.fn().mockResolvedValue("first-commit"),
-        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
 
@@ -168,6 +152,7 @@ describe("createGitHubRelease", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: vi.fn().mockResolvedValue({
+          id: 2,
           html_url: "https://github.com/pubm/pubm/releases/tag/v2.0.0-beta.1",
           upload_url:
             "https://uploads.github.com/repos/pubm/pubm/releases/2/assets{?name,label}",
@@ -184,10 +169,10 @@ describe("createGitHubRelease", () => {
 
     const platform = { raw: "linux-x64", os: "linux", arch: "x64" };
     const result = await createGitHubRelease({} as any, {
-      packageName: "pubm",
+      displayLabel: "pubm",
       version: "2.0.0-beta.1",
       tag: "v2.0.0-beta.1",
-      changelogBody: "Release notes from CHANGELOG",
+      body: "Release notes from CHANGELOG",
       assets: [
         {
           filePath: "/tmp/pubm-linux-x64.tar.gz",
@@ -223,9 +208,6 @@ describe("createGitHubRelease", () => {
         repository: vi
           .fn()
           .mockResolvedValue("https://github.com/pubm/pubm.git"),
-        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
-        firstCommit: vi.fn().mockResolvedValue("first"),
-        commits: vi.fn().mockResolvedValue([{ id: "skip", message: "skip" }]),
       } as any;
     } as any);
 
@@ -236,9 +218,10 @@ describe("createGitHubRelease", () => {
     }) as any;
 
     const result = await createGitHubRelease({} as any, {
-      packageName: "pubm",
+      displayLabel: "pubm",
       version: "1.0.0",
       tag: "v1.0.0",
+      body: "some body",
       assets: [],
     });
 
@@ -254,10 +237,6 @@ describe("createGitHubRelease", () => {
         repository: vi
           .fn()
           .mockResolvedValue("https://github.com/pubm/pubm.git"),
-        latestTag: vi.fn().mockResolvedValue("v1.0.0"),
-        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
-        firstCommit: vi.fn().mockResolvedValue("first"),
-        commits: vi.fn().mockResolvedValue([{ id: "skip", message: "skip" }]),
       } as any;
     } as any);
 
@@ -269,9 +248,10 @@ describe("createGitHubRelease", () => {
 
     await expect(
       createGitHubRelease({} as any, {
-        packageName: "pubm",
+        displayLabel: "pubm",
         version: "1.0.0",
         tag: "v1.0.0",
+        body: "some body",
         assets: [],
       }),
     ).rejects.toThrow(
@@ -289,10 +269,6 @@ describe("createGitHubRelease", () => {
         repository: vi
           .fn()
           .mockResolvedValue("https://github.com/pubm/pubm.git"),
-        latestTag: vi.fn().mockResolvedValue("v1.2.0"),
-        previousTag: vi.fn().mockResolvedValue("v1.1.0"),
-        firstCommit: vi.fn().mockResolvedValue("first-commit"),
-        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
 
@@ -301,6 +277,7 @@ describe("createGitHubRelease", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: vi.fn().mockResolvedValue({
+          id: 1,
           html_url: "https://github.com/pubm/pubm/releases/tag/v1.2.0",
           upload_url:
             "https://uploads.github.com/repos/pubm/pubm/releases/1/assets{?name,label}",
@@ -314,9 +291,10 @@ describe("createGitHubRelease", () => {
 
     await expect(
       createGitHubRelease({} as any, {
-        packageName: "pubm",
+        displayLabel: "pubm",
         version: "1.2.0",
         tag: "v1.2.0",
+        body: "some body",
         assets: [
           {
             filePath: "/tmp/pubm-linux-x64.tar.gz",
@@ -347,9 +325,10 @@ describe("createGitHubRelease", () => {
 
     await expect(
       createGitHubRelease({} as any, {
-        packageName: "pubm",
+        displayLabel: "pubm",
         version: "1.0.0",
         tag: "v1.0.0",
+        body: "",
         assets: [],
       }),
     ).rejects.toThrow(/Cannot parse owner\/repo from remote URL/);

--- a/packages/core/tests/unit/tasks/github-release.test.ts
+++ b/packages/core/tests/unit/tasks/github-release.test.ts
@@ -78,16 +78,13 @@ describe("createGitHubRelease", () => {
     });
     global.fetch = fetchMock as any;
 
-    const result = await createGitHubRelease(
-      {} as any,
-      {
-        displayLabel: "pubm",
-        version: "1.2.0",
-        tag: "v1.2.0",
-        body: "### Features\n\n- fix #42 (abcdef1)",
-        assets: [],
-      },
-    );
+    const result = await createGitHubRelease({} as any, {
+      displayLabel: "pubm",
+      version: "1.2.0",
+      tag: "v1.2.0",
+      body: "### Features\n\n- fix #42 (abcdef1)",
+      assets: [],
+    });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -46,6 +46,57 @@ function makeCtx(overrides: Record<string, any> = {}) {
   } as any;
 }
 
+describe("renderReleaseNoteSections — additional cases", () => {
+  it("renders mixed categorized and uncategorized sections together", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
+    const sections: ChangelogSection[] = [
+      { category: "Features", items: ["- add feature (a1b2c3d)"] },
+      { items: ["- misc change (b2c3d4e)"] },
+      { category: "Bug Fixes", items: ["- fix bug (c3d4e5f)"] },
+    ];
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toBe(
+      "### Features\n\n- add feature (a1b2c3d)\n\n- misc change (b2c3d4e)\n\n### Bug Fixes\n\n- fix bug (c3d4e5f)",
+    );
+  });
+
+  it("renders all 5 category types", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
+    const sections: ChangelogSection[] = [
+      { category: "Features", items: ["- feat item (a1b2c3d)"] },
+      { category: "Bug Fixes", items: ["- fix item (b2c3d4e)"] },
+      { category: "Performance", items: ["- perf item (c3d4e5f)"] },
+      { category: "Refactoring", items: ["- refactor item (d4e5f6a)"] },
+      { category: "Documentation", items: ["- docs item (e5f6a7b)"] },
+    ];
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toContain("### Features");
+    expect(result).toContain("### Bug Fixes");
+    expect(result).toContain("### Performance");
+    expect(result).toContain("### Refactoring");
+    expect(result).toContain("### Documentation");
+    // Sections joined with double newline
+    const parts = result.split("\n\n");
+    expect(parts.length).toBe(10); // 5 headers + 5 item groups
+  });
+
+  it("renders single section with many items (10+)", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
+    const items = Array.from(
+      { length: 12 },
+      (_, i) => `- item ${i + 1} (${i.toString(16).padStart(7, "0")})`,
+    );
+    const sections: ChangelogSection[] = [{ category: "Features", items }];
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toContain("### Features");
+    for (const item of items) {
+      expect(result).toContain(item);
+    }
+    // All items joined with single newline inside section
+    expect(result).toBe(`### Features\n\n${items.join("\n")}`);
+  });
+});
+
 describe("renderReleaseNoteSections", () => {
   it("renders sections with category headers", async () => {
     const { renderReleaseNoteSections } = await freshImport();
@@ -312,6 +363,448 @@ describe("buildReleaseBody", () => {
   });
 });
 
+describe("buildReleaseBody — additional cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses firstCommit fallback when previousTag is null", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue(null),
+        firstCommit: vi.fn().mockResolvedValue("abc123first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: new feature" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: new feature\n\nCOMMIT_FILES\nsrc/index.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("abc123first...v1.0.0");
+    expect(result).toContain("**Full Changelog**");
+  });
+
+  it("uses pre-resolved previousTag without calling git.previousTag", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 1.0.0\n\n- pre-resolved feature\n",
+    );
+    const mockPreviousTag = vi.fn();
+    const mockFirstCommit = vi.fn();
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: mockPreviousTag,
+        firstCommit: mockFirstCommit,
+      } as any;
+    } as any);
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+      previousTag: "v0.8.0",
+    });
+
+    expect(mockPreviousTag).not.toHaveBeenCalled();
+    expect(mockFirstCommit).not.toHaveBeenCalled();
+    expect(result).toContain("v0.8.0...v1.0.0");
+  });
+
+  it("reads CHANGELOG.md from ctx.cwd for root package (no pkgPath)", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockImplementation((p: string) => p === "/project/CHANGELOG.md");
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 1.0.0\n\n- root package feature\n",
+    );
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+      } as any;
+    } as any);
+
+    const result = await buildReleaseBody(makeCtx(), {
+      // no pkgPath — root package
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("root package feature");
+    // Should have checked /project/CHANGELOG.md (no subdirectory)
+    expect(mockExistsSync).toHaveBeenCalledWith("/project/CHANGELOG.md");
+  });
+
+  it("falls through to commits when CHANGELOG.md version section not found", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit, mockExecFileSync } =
+      await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    // CHANGELOG exists but doesn't have 1.0.0 section
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 0.9.0\n\n- old entry\n",
+    );
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: fallback feature" },
+        ]),
+      } as any;
+    } as any);
+    // execFileSync has commit touching packages/core — will be included
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: fallback feature\n\nCOMMIT_FILES\npackages/core/src/index.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    // CHANGELOG section missing → falls through to conventional commits path
+    expect(result).not.toContain("old entry");
+    expect(result).toContain("fallback feature");
+    // Conventional commit parsing should produce a Features section
+    expect(result).toContain("### Features");
+  });
+
+  it("returns only compare link when commits list is empty", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        // Only returns the boundary commit (which gets sliced off), leaving empty
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue("");
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toBe(
+      "**Full Changelog**: https://github.com/user/repo/compare/v0.9.0...v1.0.0",
+    );
+  });
+
+  it("treats breaking change commit (feat!) as Features", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat!: breaking change" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat!: breaking change\n\nCOMMIT_FILES\nsrc/index.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "2.0.0",
+      tag: "v2.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("breaking change");
+    expect(result).toContain("### Features");
+  });
+
+  it("handles scoped conventional commit (feat(core): ...)", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat(core): scoped feature" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat(core): scoped feature\n\nCOMMIT_FILES\npackages/core/src/index.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("scoped feature");
+    expect(result).toContain("### Features");
+  });
+
+  it("falls back to raw commits when all conventional commits are filtered out by scope", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          // Raw commits include the full message as stored by git
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: only cli change" },
+        ]),
+      } as any;
+    } as any);
+    // Only file is in packages/pubm — not in packages/core
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: only cli change\n\nCOMMIT_FILES\npackages/pubm/src/cli.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    // Should fall back to raw commits since all conventional commits are filtered by scope
+    // Raw fallback uses the full message from git.commits (not stripped description)
+    expect(result).toContain("- feat: only cli change (abcdef1)");
+    expect(result).not.toContain("### Features");
+  });
+
+  it("includes all commit types when multiple types are present", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "aaaaaaa1234567890abcdef1234567890abcdef12", message: "feat: new api" },
+          { id: "bbbbbbb1234567890abcdef1234567890abcdef12", message: "fix: memory leak" },
+          { id: "ccccccc1234567890abcdef1234567890abcdef12", message: "perf: faster render" },
+          { id: "ddddddd1234567890abcdef1234567890abcdef12", message: "docs: update readme" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START aaaaaaa\nfeat: new api\n\nCOMMIT_FILES\nsrc/api.ts\n" +
+        "COMMIT_START bbbbbbb\nfix: memory leak\n\nCOMMIT_FILES\nsrc/core.ts\n" +
+        "COMMIT_START ccccccc\nperf: faster render\n\nCOMMIT_FILES\nsrc/render.ts\n" +
+        "COMMIT_START ddddddd\ndocs: update readme\n\nCOMMIT_FILES\nREADME.md\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("### Features");
+    expect(result).toContain("new api");
+    expect(result).toContain("### Bug Fixes");
+    expect(result).toContain("memory leak");
+    expect(result).toContain("faster render");
+    expect(result).toContain("update readme");
+  });
+
+  it("uses only first line of multi-line commit message as description", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: first line\n\ndetailed body that should not appear" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: first line\n\ndetailed body that should not appear\n\nCOMMIT_FILES\nsrc/index.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("first line");
+    expect(result).not.toContain("detailed body that should not appear");
+  });
+
+  it("returns compare link when getCommitsBetweenRefs returns empty output", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        // Simulate: git.commits returns just boundary commit (gets sliced to empty)
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+        ]),
+      } as any;
+    } as any);
+    // execFileSync returns empty string (no commits in range)
+    mockExecFileSync.mockReturnValue("");
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toBe(
+      "**Full Changelog**: https://github.com/user/repo/compare/v0.9.0...v1.0.0",
+    );
+    expect(result).not.toContain("undefined");
+  });
+
+  it("gracefully handles getCommitsBetweenRefs throwing by falling back to raw commits", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "chore: some change" },
+        ]),
+      } as any;
+    } as any);
+    // Simulate execFileSync throwing (e.g., git not available or invalid ref)
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("git command failed");
+    });
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    // getCommitsBetweenRefs catches and returns [], so parsed/filtered are empty
+    // Falls back to raw commits from git.commits — raw fallback uses full message
+    expect(result).toContain("- chore: some change (abcdef1)");
+    expect(result).toContain("**Full Changelog**");
+  });
+
+  it("commits with no files are still parsed correctly", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: no file commit" },
+        ]),
+      } as any;
+    } as any);
+    // Commit with empty files section
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: no file commit\n\nCOMMIT_FILES\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    // No pkgPath filter, so should appear in Features
+    expect(result).toContain("no file commit");
+    expect(result).toContain("### Features");
+  });
+
+  it("handles single commit without separator between commits", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "fix: single commit fix" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfix: single commit fix\n\nCOMMIT_FILES\nsrc/fix.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("single commit fix");
+    expect(result).toContain("### Bug Fixes");
+  });
+});
+
 describe("buildFixedReleaseBody", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -418,6 +911,203 @@ describe("buildFixedReleaseBody", () => {
   });
 });
 
+describe("buildFixedReleaseBody — additional cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("single package in fixed mode produces no separator", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 1.0.0\n\n- only package feature\n",
+    );
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+      } as any;
+    } as any);
+
+    const ctx = makeCtx({
+      config: { packages: [{ path: "packages/core", name: "@pubm/core" }] },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [{ pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" }],
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## @pubm/core v1.0.0");
+    expect(result).toContain("only package feature");
+    expect(result).not.toContain("---");
+    // Single compare link at end
+    const compareMatches = result.match(/\*\*Full Changelog\*\*/g);
+    expect(compareMatches).toHaveLength(1);
+  });
+
+  it("three packages with mixed sources (changelog, conventional, raw)", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit, mockExecFileSync } =
+      await getMocks();
+
+    // Package 1: has CHANGELOG
+    // Package 2: no CHANGELOG, conventional commits
+    // Package 3: no CHANGELOG, raw commits
+    mockExistsSync
+      .mockReturnValueOnce(true)   // pkg1 changelog exists
+      .mockReturnValueOnce(false)  // pkg2 changelog missing
+      .mockReturnValueOnce(false); // pkg3 changelog missing
+
+    mockReadFileSync.mockReturnValueOnce(
+      "# Changelog\n\n## 1.0.0\n\n- changelog entry\n",
+    );
+
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: conventional feat" },
+          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "non-conventional raw" },
+        ]),
+      } as any;
+    } as any);
+
+    mockExecFileSync
+      // pkg2: has conventional commit in its path
+      .mockReturnValueOnce(
+        "COMMIT_START abcdef1\nfeat: conventional feat\n\nCOMMIT_FILES\npackages/pkg2/src/index.ts\n",
+      )
+      // pkg3: no conventional commits → falls back to raw
+      .mockReturnValueOnce(
+        "COMMIT_START bcdef12\nnon-conventional raw\n\nCOMMIT_FILES\npackages/pkg3/src/index.ts\n",
+      );
+
+    const ctx = makeCtx({
+      config: {
+        packages: [
+          { path: "packages/pkg1", name: "pkg1" },
+          { path: "packages/pkg2", name: "pkg2" },
+          { path: "packages/pkg3", name: "pkg3" },
+        ],
+      },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [
+        { pkgPath: "packages/pkg1", pkgName: "pkg1", version: "1.0.0" },
+        { pkgPath: "packages/pkg2", pkgName: "pkg2", version: "1.0.0" },
+        { pkgPath: "packages/pkg3", pkgName: "pkg3", version: "1.0.0" },
+      ],
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## pkg1 v1.0.0");
+    expect(result).toContain("changelog entry");
+    expect(result).toContain("## pkg2 v1.0.0");
+    expect(result).toContain("conventional feat");
+    expect(result).toContain("## pkg3 v1.0.0");
+    // Pkg3 uses raw since only raw commit exists and it matches pkg3 path
+    // (raw path is separate — comes from git.commits not filtered by scope)
+    expect(result).toContain("non-conventional raw");
+    // Two separators for three packages
+    const separators = result.match(/---/g);
+    expect(separators).toHaveLength(2);
+    // Single compare link
+    const compareMatches = result.match(/\*\*Full Changelog\*\*/g);
+    expect(compareMatches).toHaveLength(1);
+  });
+
+  it("packages with different versions each show correct version in header", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync
+      .mockReturnValueOnce("# Changelog\n\n## 2.1.0\n\n- core update\n")
+      .mockReturnValueOnce("# Changelog\n\n## 1.5.3\n\n- cli patch\n");
+
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v2.0.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+      } as any;
+    } as any);
+
+    const ctx = makeCtx({
+      config: {
+        packages: [
+          { path: "packages/core", name: "@pubm/core" },
+          { path: "packages/pubm", name: "pubm" },
+        ],
+      },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [
+        { pkgPath: "packages/core", pkgName: "@pubm/core", version: "2.1.0" },
+        { pkgPath: "packages/pubm", pkgName: "pubm", version: "1.5.3" },
+      ],
+      tag: "v2.1.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## @pubm/core v2.1.0");
+    expect(result).toContain("## pubm v1.5.3");
+    expect(result).toContain("core update");
+    expect(result).toContain("cli patch");
+  });
+
+  it("all packages with empty content still produce headers and compare link", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        // Only boundary commit, sliced to empty
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue("");
+
+    const ctx = makeCtx({
+      config: {
+        packages: [
+          { path: "packages/core", name: "@pubm/core" },
+          { path: "packages/pubm", name: "pubm" },
+        ],
+      },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [
+        { pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" },
+        { pkgPath: "packages/pubm", pkgName: "pubm", version: "1.0.0" },
+      ],
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## @pubm/core v1.0.0");
+    expect(result).toContain("## pubm v1.0.0");
+    expect(result).toContain("**Full Changelog**");
+    // Compare link only once
+    const compareMatches = result.match(/\*\*Full Changelog\*\*/g);
+    expect(compareMatches).toHaveLength(1);
+  });
+});
+
 describe("truncateForUrl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -466,5 +1156,91 @@ describe("truncateForUrl", () => {
     expect(result.body).toContain("truncated");
     expect(result.truncated).toBe(true);
     expect(result.clipboardCopied).toBe(false);
+  });
+});
+
+describe("truncateForUrl — additional cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("body exactly at the URL limit is not truncated", async () => {
+    const { truncateForUrl } = await freshImport();
+
+    // MAX_URL_LENGTH is 8000
+    // We need baseUrl + encodeURIComponent(body) == 8000 exactly
+    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    // ASCII chars encode to themselves, so body length = 8000 - baseUrl.length
+    const bodyLength = 8000 - baseUrl.length;
+    const body = "a".repeat(bodyLength);
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.truncated).toBe(false);
+    expect(result.body).toBe(body);
+    expect(result.clipboardCopied).toBe(false);
+  });
+
+  it("body with newlines expands when encoded — triggers truncation", async () => {
+    const { truncateForUrl } = await freshImport();
+    const { mockCopyToClipboard } = await getMocks();
+    mockCopyToClipboard.mockResolvedValue(true);
+
+    // Newlines encode as %0A (3 chars each), so far fewer newlines needed to hit limit
+    // Create a body with many newlines that would expand beyond limit
+    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    // 3000 newlines = 9000 encoded chars, which exceeds 8000
+    const body = "\n".repeat(3000);
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.truncated).toBe(true);
+    expect(result.body.length).toBeLessThan(body.length);
+  });
+
+  it("very long baseUrl leaves less room for body", async () => {
+    const { truncateForUrl } = await freshImport();
+    const { mockCopyToClipboard } = await getMocks();
+    mockCopyToClipboard.mockResolvedValue(false);
+
+    // A short body that would normally pass, but a very long baseUrl consumes the budget
+    const longBaseUrl =
+      "https://github.com/user/very-long-org-name/very-long-repo-name/releases/new?" +
+      "tag=v1.0.0&prerelease=false&generate_release_notes=false&" +
+      "x=".padEnd(7900, "a") +
+      "body=";
+    const body = "x".repeat(200);
+
+    const result = await truncateForUrl(body, longBaseUrl);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("empty body returns as-is without truncation", async () => {
+    const { truncateForUrl } = await freshImport();
+
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    const result = await truncateForUrl("", baseUrl);
+
+    expect(result.body).toBe("");
+    expect(result.truncated).toBe(false);
+    expect(result.clipboardCopied).toBe(false);
+  });
+
+  it("truncated body does not cut mid-word — binary search handles boundary correctly", async () => {
+    const { truncateForUrl } = await freshImport();
+    const { mockCopyToClipboard } = await getMocks();
+    mockCopyToClipboard.mockResolvedValue(false);
+
+    // Use a body with special chars (% signs expand 3x in URL encoding)
+    // Enough %'s to force truncation
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    const body = "%".repeat(3000);
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.truncated).toBe(true);
+    // The truncated body + suffix should stay within limit when encoded
+    const fullUrl = `${baseUrl}${encodeURIComponent(result.body)}`;
+    expect(fullUrl.length).toBeLessThanOrEqual(8000);
+    expect(result.body).toContain("truncated");
   });
 });

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -1,44 +1,262 @@
-import { describe, expect, it } from "vitest";
-import { renderReleaseNoteSections } from "../../../src/tasks/release-notes.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChangelogSection } from "../../../src/changelog/types.js";
 
+// These vi.mock calls MUST be at file top level
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("../../../src/git.js", () => ({
+  Git: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+async function freshImport() {
+  vi.resetModules();
+  return await import("../../../src/tasks/release-notes.js");
+}
+
+async function getMocks() {
+  const fs = await import("node:fs");
+  const { Git } = await import("../../../src/git.js");
+  const { execFileSync } = await import("node:child_process");
+  return {
+    mockExistsSync: vi.mocked(fs.existsSync),
+    mockReadFileSync: vi.mocked(fs.readFileSync),
+    mockGit: vi.mocked(Git),
+    mockExecFileSync: vi.mocked(execFileSync),
+  };
+}
+
+function makeCtx(overrides: Record<string, any> = {}) {
+  return {
+    cwd: "/project",
+    config: { packages: [{ path: "packages/core", name: "@pubm/core" }] },
+    ...overrides,
+  } as any;
+}
+
 describe("renderReleaseNoteSections", () => {
-  it("renders sections with category headers", () => {
+  it("renders sections with category headers", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
     const sections: ChangelogSection[] = [
       { category: "Features", items: ["- add glob support (a1b2c3d)"] },
       { category: "Bug Fixes", items: ["- fix path resolution (c3d4e5f)"] },
     ];
-
     const result = renderReleaseNoteSections(sections);
     expect(result).toBe(
       "### Features\n\n- add glob support (a1b2c3d)\n\n### Bug Fixes\n\n- fix path resolution (c3d4e5f)",
     );
   });
 
-  it("renders multiple items within a section", () => {
+  it("renders multiple items within a section", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
     const sections: ChangelogSection[] = [
-      {
-        category: "Features",
-        items: ["- feat one (a1b2c3d)", "- feat two (b2c3d4e)"],
-      },
+      { category: "Features", items: ["- feat one (a1b2c3d)", "- feat two (b2c3d4e)"] },
     ];
-
     const result = renderReleaseNoteSections(sections);
-    expect(result).toBe(
-      "### Features\n\n- feat one (a1b2c3d)\n- feat two (b2c3d4e)",
-    );
+    expect(result).toBe("### Features\n\n- feat one (a1b2c3d)\n- feat two (b2c3d4e)");
   });
 
-  it("returns empty string for empty sections", () => {
+  it("returns empty string for empty sections", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
     expect(renderReleaseNoteSections([])).toBe("");
   });
 
-  it("renders sections without category as plain items", () => {
-    const sections: ChangelogSection[] = [
-      { items: ["- uncategorized item (abc1234)"] },
-    ];
-
+  it("renders sections without category as plain items", async () => {
+    const { renderReleaseNoteSections } = await freshImport();
+    const sections: ChangelogSection[] = [{ items: ["- uncategorized item (abc1234)"] }];
     const result = renderReleaseNoteSections(sections);
     expect(result).toBe("- uncategorized item (abc1234)");
+  });
+});
+
+describe("buildReleaseBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses CHANGELOG.md when available", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 1.0.0\n\n### Minor Changes\n\n- new feature\n\n## 0.9.0\n\n- old\n",
+    );
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("abc123"),
+      } as any;
+    } as any);
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("### Minor Changes");
+    expect(result).toContain("- new feature");
+    expect(result).toContain("**Full Changelog**: https://github.com/user/repo/compare/v0.9.0...v1.0.0");
+  });
+
+  it("falls back to conventional commits when no CHANGELOG.md", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: add glob support" },
+          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "fix: resolve path issue" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: add glob support\n\nCOMMIT_FILES\nsrc/glob.ts\n" +
+      "COMMIT_START bcdef12\nfix: resolve path issue\n\nCOMMIT_FILES\nsrc/path.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("### Features");
+    expect(result).toContain("add glob support");
+    expect(result).toContain("### Bug Fixes");
+    expect(result).toContain("resolve path issue");
+    expect(result).toContain("**Full Changelog**");
+  });
+
+  it("filters commits by package scope in monorepo independent mode", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: add core feature" },
+          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "fix: fix cli bug" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: add core feature\n\nCOMMIT_FILES\npackages/core/src/index.ts\n" +
+      "COMMIT_START bcdef12\nfix: fix cli bug\n\nCOMMIT_FILES\npackages/pubm/src/cli.ts\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("add core feature");
+    expect(result).not.toContain("fix cli bug");
+  });
+
+  it("falls back to raw commit list when no conventional commits", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "update dependencies" },
+          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "bump version" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nupdate dependencies\n\nCOMMIT_FILES\n" +
+      "COMMIT_START bcdef12\nbump version\n\nCOMMIT_FILES\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("- update dependencies (abcdef1)");
+    expect(result).toContain("- bump version (bcdef12)");
+    expect(result).toContain("**Full Changelog**");
+  });
+
+  it("uses conventional path when at least one commit is conventional", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockGit, mockExecFileSync } = await getMocks();
+
+    mockExistsSync.mockReturnValue(false);
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue(null),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: one conventional" },
+          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "non-conventional message" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nfeat: one conventional\n\nCOMMIT_FILES\n" +
+      "COMMIT_START bcdef12\nnon-conventional message\n\nCOMMIT_FILES\n",
+    );
+
+    const result = await buildReleaseBody(makeCtx(), {
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("### Features");
+    expect(result).toContain("one conventional");
+  });
+
+  it("omits compare link when appendCompareLink is false", async () => {
+    const { buildReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("# Changelog\n\n## 1.0.0\n\n- feature\n");
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("abc123"),
+      } as any;
+    } as any);
+
+    const result = await buildReleaseBody(makeCtx(), {
+      pkgPath: "packages/core",
+      version: "1.0.0",
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+      appendCompareLink: false,
+    });
+
+    expect(result).not.toContain("**Full Changelog**");
   });
 });

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -378,8 +378,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue(null),
         firstCommit: vi.fn().mockResolvedValue("abc123first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: new feature" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: new feature",
+          },
         ]),
       } as any;
     } as any);
@@ -431,7 +437,9 @@ describe("buildReleaseBody — additional cases", () => {
     const { buildReleaseBody } = await freshImport();
     const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
 
-    mockExistsSync.mockImplementation((p: string) => p === "/project/CHANGELOG.md");
+    mockExistsSync.mockImplementation(
+      (p: string) => p === "/project/CHANGELOG.md",
+    );
     mockReadFileSync.mockReturnValue(
       "# Changelog\n\n## 1.0.0\n\n- root package feature\n",
     );
@@ -469,8 +477,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: fallback feature" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: fallback feature",
+          },
         ]),
       } as any;
     } as any);
@@ -504,7 +518,10 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         // Only returns the boundary commit (which gets sliced off), leaving empty
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
         ]),
       } as any;
     } as any);
@@ -531,8 +548,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat!: breaking change" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat!: breaking change",
+          },
         ]),
       } as any;
     } as any);
@@ -560,8 +583,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat(core): scoped feature" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat(core): scoped feature",
+          },
         ]),
       } as any;
     } as any);
@@ -590,9 +619,15 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
           // Raw commits include the full message as stored by git
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: only cli change" },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: only cli change",
+          },
         ]),
       } as any;
     } as any);
@@ -624,11 +659,26 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "aaaaaaa1234567890abcdef1234567890abcdef12", message: "feat: new api" },
-          { id: "bbbbbbb1234567890abcdef1234567890abcdef12", message: "fix: memory leak" },
-          { id: "ccccccc1234567890abcdef1234567890abcdef12", message: "perf: faster render" },
-          { id: "ddddddd1234567890abcdef1234567890abcdef12", message: "docs: update readme" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "aaaaaaa1234567890abcdef1234567890abcdef12",
+            message: "feat: new api",
+          },
+          {
+            id: "bbbbbbb1234567890abcdef1234567890abcdef12",
+            message: "fix: memory leak",
+          },
+          {
+            id: "ccccccc1234567890abcdef1234567890abcdef12",
+            message: "perf: faster render",
+          },
+          {
+            id: "ddddddd1234567890abcdef1234567890abcdef12",
+            message: "docs: update readme",
+          },
         ]),
       } as any;
     } as any);
@@ -663,8 +713,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: first line\n\ndetailed body that should not appear" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: first line\n\ndetailed body that should not appear",
+          },
         ]),
       } as any;
     } as any);
@@ -693,7 +749,10 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         // Simulate: git.commits returns just boundary commit (gets sliced to empty)
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
         ]),
       } as any;
     } as any);
@@ -722,8 +781,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "chore: some change" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "chore: some change",
+          },
         ]),
       } as any;
     } as any);
@@ -754,8 +819,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: no file commit" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: no file commit",
+          },
         ]),
       } as any;
     } as any);
@@ -785,8 +856,14 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "fix: single commit fix" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "fix: single commit fix",
+          },
         ]),
       } as any;
     } as any);
@@ -936,7 +1013,9 @@ describe("buildFixedReleaseBody — additional cases", () => {
     });
 
     const result = await buildFixedReleaseBody(ctx, {
-      packages: [{ pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" }],
+      packages: [
+        { pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" },
+      ],
       tag: "v1.0.0",
       repositoryUrl: "https://github.com/user/repo",
     });
@@ -958,8 +1037,8 @@ describe("buildFixedReleaseBody — additional cases", () => {
     // Package 2: no CHANGELOG, conventional commits
     // Package 3: no CHANGELOG, raw commits
     mockExistsSync
-      .mockReturnValueOnce(true)   // pkg1 changelog exists
-      .mockReturnValueOnce(false)  // pkg2 changelog missing
+      .mockReturnValueOnce(true) // pkg1 changelog exists
+      .mockReturnValueOnce(false) // pkg2 changelog missing
       .mockReturnValueOnce(false); // pkg3 changelog missing
 
     mockReadFileSync.mockReturnValueOnce(
@@ -971,9 +1050,18 @@ describe("buildFixedReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: conventional feat" },
-          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "non-conventional raw" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: conventional feat",
+          },
+          {
+            id: "bcdef1234567890abcdef1234567890abcdef123",
+            message: "non-conventional raw",
+          },
         ]),
       } as any;
     } as any);
@@ -1075,7 +1163,10 @@ describe("buildFixedReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         // Only boundary commit, sliced to empty
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
         ]),
       } as any;
     } as any);
@@ -1169,7 +1260,8 @@ describe("truncateForUrl — additional cases", () => {
 
     // MAX_URL_LENGTH is 8000
     // We need baseUrl + encodeURIComponent(body) == 8000 exactly
-    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
     // ASCII chars encode to themselves, so body length = 8000 - baseUrl.length
     const bodyLength = 8000 - baseUrl.length;
     const body = "a".repeat(bodyLength);
@@ -1187,7 +1279,8 @@ describe("truncateForUrl — additional cases", () => {
 
     // Newlines encode as %0A (3 chars each), so far fewer newlines needed to hit limit
     // Create a body with many newlines that would expand beyond limit
-    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&body=";
     // 3000 newlines = 9000 encoded chars, which exceeds 8000
     const body = "\n".repeat(3000);
 

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChangelogSection } from "../../../src/changelog/types.js";
 
@@ -184,10 +185,6 @@ describe("buildReleaseBody", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: add glob support",
           },
@@ -227,10 +224,6 @@ describe("buildReleaseBody", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: add core feature",
           },
@@ -268,10 +261,6 @@ describe("buildReleaseBody", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "update dependencies",
           },
@@ -308,10 +297,6 @@ describe("buildReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue(null),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: one conventional",
@@ -379,10 +364,6 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("abc123first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: new feature",
           },
@@ -438,7 +419,7 @@ describe("buildReleaseBody — additional cases", () => {
     const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
 
     mockExistsSync.mockImplementation(
-      (p: string) => p === "/project/CHANGELOG.md",
+      (p: string) => p === join("/project", "CHANGELOG.md"),
     );
     mockReadFileSync.mockReturnValue(
       "# Changelog\n\n## 1.0.0\n\n- root package feature\n",
@@ -459,7 +440,9 @@ describe("buildReleaseBody — additional cases", () => {
 
     expect(result).toContain("root package feature");
     // Should have checked /project/CHANGELOG.md (no subdirectory)
-    expect(mockExistsSync).toHaveBeenCalledWith("/project/CHANGELOG.md");
+    expect(mockExistsSync).toHaveBeenCalledWith(
+      join("/project", "CHANGELOG.md"),
+    );
   });
 
   it("falls through to commits when CHANGELOG.md version section not found", async () => {
@@ -477,10 +460,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: fallback feature",
@@ -516,13 +495,8 @@ describe("buildReleaseBody — additional cases", () => {
       return {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
-        // Only returns the boundary commit (which gets sliced off), leaving empty
-        commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-        ]),
+        // Returns empty list — no commits in this release
+        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue("");
@@ -548,10 +522,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat!: breaking change",
@@ -584,10 +554,6 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat(core): scoped feature",
           },
@@ -619,10 +585,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           // Raw commits include the full message as stored by git
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
@@ -659,10 +621,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "aaaaaaa1234567890abcdef1234567890abcdef12",
             message: "feat: new api",
@@ -714,10 +672,6 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: first line\n\ndetailed body that should not appear",
           },
@@ -747,13 +701,8 @@ describe("buildReleaseBody — additional cases", () => {
       return {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
-        // Simulate: git.commits returns just boundary commit (gets sliced to empty)
-        commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-        ]),
+        // Simulate: git.commits returns empty list (no commits in range)
+        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
     // execFileSync returns empty string (no commits in range)
@@ -781,10 +730,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "chore: some change",
@@ -820,10 +765,6 @@ describe("buildReleaseBody — additional cases", () => {
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
           {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-          {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: no file commit",
           },
@@ -856,10 +797,6 @@ describe("buildReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "fix: single commit fix",
@@ -949,10 +886,6 @@ describe("buildFixedReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "update dep",
@@ -1050,10 +983,6 @@ describe("buildFixedReleaseBody — additional cases", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
           {
             id: "abcdef1234567890abcdef1234567890abcdef12",
             message: "feat: conventional feat",
@@ -1161,13 +1090,8 @@ describe("buildFixedReleaseBody — additional cases", () => {
       return {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
-        // Only boundary commit, sliced to empty
-        commits: vi.fn().mockResolvedValue([
-          {
-            id: "ignored0000000000000000000000000000000000",
-            message: "ignored",
-          },
-        ]),
+        // No commits in range
+        commits: vi.fn().mockResolvedValue([]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue("");

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -62,10 +62,15 @@ describe("renderReleaseNoteSections", () => {
   it("renders multiple items within a section", async () => {
     const { renderReleaseNoteSections } = await freshImport();
     const sections: ChangelogSection[] = [
-      { category: "Features", items: ["- feat one (a1b2c3d)", "- feat two (b2c3d4e)"] },
+      {
+        category: "Features",
+        items: ["- feat one (a1b2c3d)", "- feat two (b2c3d4e)"],
+      },
     ];
     const result = renderReleaseNoteSections(sections);
-    expect(result).toBe("### Features\n\n- feat one (a1b2c3d)\n- feat two (b2c3d4e)");
+    expect(result).toBe(
+      "### Features\n\n- feat one (a1b2c3d)\n- feat two (b2c3d4e)",
+    );
   });
 
   it("returns empty string for empty sections", async () => {
@@ -75,7 +80,9 @@ describe("renderReleaseNoteSections", () => {
 
   it("renders sections without category as plain items", async () => {
     const { renderReleaseNoteSections } = await freshImport();
-    const sections: ChangelogSection[] = [{ items: ["- uncategorized item (abc1234)"] }];
+    const sections: ChangelogSection[] = [
+      { items: ["- uncategorized item (abc1234)"] },
+    ];
     const result = renderReleaseNoteSections(sections);
     expect(result).toBe("- uncategorized item (abc1234)");
   });
@@ -110,7 +117,9 @@ describe("buildReleaseBody", () => {
 
     expect(result).toContain("### Minor Changes");
     expect(result).toContain("- new feature");
-    expect(result).toContain("**Full Changelog**: https://github.com/user/repo/compare/v0.9.0...v1.0.0");
+    expect(result).toContain(
+      "**Full Changelog**: https://github.com/user/repo/compare/v0.9.0...v1.0.0",
+    );
   });
 
   it("falls back to conventional commits when no CHANGELOG.md", async () => {
@@ -123,15 +132,24 @@ describe("buildReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: add glob support" },
-          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "fix: resolve path issue" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: add glob support",
+          },
+          {
+            id: "bcdef1234567890abcdef1234567890abcdef123",
+            message: "fix: resolve path issue",
+          },
         ]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue(
       "COMMIT_START abcdef1\nfeat: add glob support\n\nCOMMIT_FILES\nsrc/glob.ts\n" +
-      "COMMIT_START bcdef12\nfix: resolve path issue\n\nCOMMIT_FILES\nsrc/path.ts\n",
+        "COMMIT_START bcdef12\nfix: resolve path issue\n\nCOMMIT_FILES\nsrc/path.ts\n",
     );
 
     const result = await buildReleaseBody(makeCtx(), {
@@ -157,15 +175,24 @@ describe("buildReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: add core feature" },
-          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "fix: fix cli bug" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: add core feature",
+          },
+          {
+            id: "bcdef1234567890abcdef1234567890abcdef123",
+            message: "fix: fix cli bug",
+          },
         ]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue(
       "COMMIT_START abcdef1\nfeat: add core feature\n\nCOMMIT_FILES\npackages/core/src/index.ts\n" +
-      "COMMIT_START bcdef12\nfix: fix cli bug\n\nCOMMIT_FILES\npackages/pubm/src/cli.ts\n",
+        "COMMIT_START bcdef12\nfix: fix cli bug\n\nCOMMIT_FILES\npackages/pubm/src/cli.ts\n",
     );
 
     const result = await buildReleaseBody(makeCtx(), {
@@ -189,15 +216,24 @@ describe("buildReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "update dependencies" },
-          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "bump version" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "update dependencies",
+          },
+          {
+            id: "bcdef1234567890abcdef1234567890abcdef123",
+            message: "bump version",
+          },
         ]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue(
       "COMMIT_START abcdef1\nupdate dependencies\n\nCOMMIT_FILES\n" +
-      "COMMIT_START bcdef12\nbump version\n\nCOMMIT_FILES\n",
+        "COMMIT_START bcdef12\nbump version\n\nCOMMIT_FILES\n",
     );
 
     const result = await buildReleaseBody(makeCtx(), {
@@ -221,15 +257,24 @@ describe("buildReleaseBody", () => {
         previousTag: vi.fn().mockResolvedValue(null),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "feat: one conventional" },
-          { id: "bcdef1234567890abcdef1234567890abcdef123", message: "non-conventional message" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "feat: one conventional",
+          },
+          {
+            id: "bcdef1234567890abcdef1234567890abcdef123",
+            message: "non-conventional message",
+          },
         ]),
       } as any;
     } as any);
     mockExecFileSync.mockReturnValue(
       "COMMIT_START abcdef1\nfeat: one conventional\n\nCOMMIT_FILES\n" +
-      "COMMIT_START bcdef12\nnon-conventional message\n\nCOMMIT_FILES\n",
+        "COMMIT_START bcdef12\nnon-conventional message\n\nCOMMIT_FILES\n",
     );
 
     const result = await buildReleaseBody(makeCtx(), {
@@ -314,23 +359,34 @@ describe("buildFixedReleaseBody", () => {
     // Single compare link at end
     const compareMatches = result.match(/\*\*Full Changelog\*\*/g);
     expect(compareMatches).toHaveLength(1);
-    expect(result).toContain("https://github.com/user/repo/compare/v0.9.0...v1.0.0");
+    expect(result).toContain(
+      "https://github.com/user/repo/compare/v0.9.0...v1.0.0",
+    );
   });
 
   it("handles packages falling back to raw commits", async () => {
     const { buildFixedReleaseBody } = await freshImport();
-    const { mockExistsSync, mockReadFileSync, mockGit, mockExecFileSync } = await getMocks();
+    const { mockExistsSync, mockReadFileSync, mockGit, mockExecFileSync } =
+      await getMocks();
 
     // First package has changelog, second doesn't
     mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
-    mockReadFileSync.mockReturnValue("# Changelog\n\n## 1.0.0\n\n- core feature\n");
+    mockReadFileSync.mockReturnValue(
+      "# Changelog\n\n## 1.0.0\n\n- core feature\n",
+    );
     mockGit.mockImplementation(function () {
       return {
         previousTag: vi.fn().mockResolvedValue("v0.9.0"),
         firstCommit: vi.fn().mockResolvedValue("first"),
         commits: vi.fn().mockResolvedValue([
-          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
-          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "update dep" },
+          {
+            id: "ignored0000000000000000000000000000000000",
+            message: "ignored",
+          },
+          {
+            id: "abcdef1234567890abcdef1234567890abcdef12",
+            message: "update dep",
+          },
         ]),
       } as any;
     } as any);
@@ -371,7 +427,8 @@ describe("truncateForUrl", () => {
     const { truncateForUrl } = await freshImport();
 
     const body = "short body";
-    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
 
     const result = await truncateForUrl(body, baseUrl);
     expect(result.body).toBe(body);
@@ -385,7 +442,8 @@ describe("truncateForUrl", () => {
     mockCopyToClipboard.mockResolvedValue(true);
 
     const body = "x".repeat(10000);
-    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
 
     const result = await truncateForUrl(body, baseUrl);
     expect(result.body.length).toBeLessThan(body.length);
@@ -401,7 +459,8 @@ describe("truncateForUrl", () => {
     mockCopyToClipboard.mockResolvedValue(false);
 
     const body = "x".repeat(10000);
-    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+    const baseUrl =
+      "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
 
     const result = await truncateForUrl(body, baseUrl);
     expect(result.body).toContain("truncated");

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -260,3 +260,98 @@ describe("buildReleaseBody", () => {
     expect(result).not.toContain("**Full Changelog**");
   });
 });
+
+describe("buildFixedReleaseBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates per-package bodies with headers and single compare link", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit } = await getMocks();
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync
+      .mockReturnValueOnce("# Changelog\n\n## 1.0.0\n\n- core feature\n")
+      .mockReturnValueOnce("# Changelog\n\n## 1.0.0\n\n- cli update\n");
+
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+      } as any;
+    } as any);
+
+    const ctx = makeCtx({
+      config: {
+        packages: [
+          { path: "packages/core", name: "@pubm/core" },
+          { path: "packages/pubm", name: "pubm" },
+        ],
+      },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [
+        { pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" },
+        { pkgPath: "packages/pubm", pkgName: "pubm", version: "1.0.0" },
+      ],
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## @pubm/core v1.0.0");
+    expect(result).toContain("- core feature");
+    expect(result).toContain("---");
+    expect(result).toContain("## pubm v1.0.0");
+    expect(result).toContain("- cli update");
+    // Single compare link at end
+    const compareMatches = result.match(/\*\*Full Changelog\*\*/g);
+    expect(compareMatches).toHaveLength(1);
+    expect(result).toContain("https://github.com/user/repo/compare/v0.9.0...v1.0.0");
+  });
+
+  it("handles packages falling back to raw commits", async () => {
+    const { buildFixedReleaseBody } = await freshImport();
+    const { mockExistsSync, mockReadFileSync, mockGit, mockExecFileSync } = await getMocks();
+
+    // First package has changelog, second doesn't
+    mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
+    mockReadFileSync.mockReturnValue("# Changelog\n\n## 1.0.0\n\n- core feature\n");
+    mockGit.mockImplementation(function () {
+      return {
+        previousTag: vi.fn().mockResolvedValue("v0.9.0"),
+        firstCommit: vi.fn().mockResolvedValue("first"),
+        commits: vi.fn().mockResolvedValue([
+          { id: "ignored0000000000000000000000000000000000", message: "ignored" },
+          { id: "abcdef1234567890abcdef1234567890abcdef12", message: "update dep" },
+        ]),
+      } as any;
+    } as any);
+    mockExecFileSync.mockReturnValue(
+      "COMMIT_START abcdef1\nupdate dep\n\nCOMMIT_FILES\n",
+    );
+
+    const ctx = makeCtx({
+      config: {
+        packages: [
+          { path: "packages/core", name: "@pubm/core" },
+          { path: "packages/pubm", name: "pubm" },
+        ],
+      },
+    });
+
+    const result = await buildFixedReleaseBody(ctx, {
+      packages: [
+        { pkgPath: "packages/core", pkgName: "@pubm/core", version: "1.0.0" },
+        { pkgPath: "packages/pubm", pkgName: "pubm", version: "1.0.0" },
+      ],
+      tag: "v1.0.0",
+      repositoryUrl: "https://github.com/user/repo",
+    });
+
+    expect(result).toContain("## @pubm/core v1.0.0");
+    expect(result).toContain("## pubm v1.0.0");
+    expect(result).toContain("- update dep (abcdef1)");
+  });
+});

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -15,6 +15,10 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
+vi.mock("../../../src/utils/clipboard.js", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
 async function freshImport() {
   vi.resetModules();
   return await import("../../../src/tasks/release-notes.js");
@@ -24,11 +28,13 @@ async function getMocks() {
   const fs = await import("node:fs");
   const { Git } = await import("../../../src/git.js");
   const { execFileSync } = await import("node:child_process");
+  const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
   return {
     mockExistsSync: vi.mocked(fs.existsSync),
     mockReadFileSync: vi.mocked(fs.readFileSync),
     mockGit: vi.mocked(Git),
     mockExecFileSync: vi.mocked(execFileSync),
+    mockCopyToClipboard: vi.mocked(copyToClipboard),
   };
 }
 
@@ -353,5 +359,53 @@ describe("buildFixedReleaseBody", () => {
     expect(result).toContain("## @pubm/core v1.0.0");
     expect(result).toContain("## pubm v1.0.0");
     expect(result).toContain("- update dep (abcdef1)");
+  });
+});
+
+describe("truncateForUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns body unchanged when URL is within limit", async () => {
+    const { truncateForUrl } = await freshImport();
+
+    const body = "short body";
+    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.body).toBe(body);
+    expect(result.truncated).toBe(false);
+    expect(result.clipboardCopied).toBe(false);
+  });
+
+  it("truncates and copies to clipboard when URL exceeds limit", async () => {
+    const { truncateForUrl } = await freshImport();
+    const { mockCopyToClipboard } = await getMocks();
+    mockCopyToClipboard.mockResolvedValue(true);
+
+    const body = "x".repeat(10000);
+    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.body.length).toBeLessThan(body.length);
+    expect(result.body).toContain("truncated");
+    expect(result.truncated).toBe(true);
+    expect(result.clipboardCopied).toBe(true);
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(body);
+  });
+
+  it("uses plain truncated message when clipboard fails", async () => {
+    const { truncateForUrl } = await freshImport();
+    const { mockCopyToClipboard } = await getMocks();
+    mockCopyToClipboard.mockResolvedValue(false);
+
+    const body = "x".repeat(10000);
+    const baseUrl = "https://github.com/user/repo/releases/new?tag=v1.0.0&prerelease=false&body=";
+
+    const result = await truncateForUrl(body, baseUrl);
+    expect(result.body).toContain("truncated");
+    expect(result.truncated).toBe(true);
+    expect(result.clipboardCopied).toBe(false);
   });
 });

--- a/packages/core/tests/unit/tasks/release-notes.test.ts
+++ b/packages/core/tests/unit/tasks/release-notes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { renderReleaseNoteSections } from "../../../src/tasks/release-notes.js";
+import type { ChangelogSection } from "../../../src/changelog/types.js";
+
+describe("renderReleaseNoteSections", () => {
+  it("renders sections with category headers", () => {
+    const sections: ChangelogSection[] = [
+      { category: "Features", items: ["- add glob support (a1b2c3d)"] },
+      { category: "Bug Fixes", items: ["- fix path resolution (c3d4e5f)"] },
+    ];
+
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toBe(
+      "### Features\n\n- add glob support (a1b2c3d)\n\n### Bug Fixes\n\n- fix path resolution (c3d4e5f)",
+    );
+  });
+
+  it("renders multiple items within a section", () => {
+    const sections: ChangelogSection[] = [
+      {
+        category: "Features",
+        items: ["- feat one (a1b2c3d)", "- feat two (b2c3d4e)"],
+      },
+    ];
+
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toBe(
+      "### Features\n\n- feat one (a1b2c3d)\n- feat two (b2c3d4e)",
+    );
+  });
+
+  it("returns empty string for empty sections", () => {
+    expect(renderReleaseNoteSections([])).toBe("");
+  });
+
+  it("renders sections without category as plain items", () => {
+    const sections: ChangelogSection[] = [
+      { items: ["- uncategorized item (abc1234)"] },
+    ];
+
+    const result = renderReleaseNoteSections(sections);
+    expect(result).toBe("- uncategorized item (abc1234)");
+  });
+});

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -289,6 +289,10 @@ vi.mock("../../../src/tasks/create-version-pr.js", () => ({
   }),
   closeVersionPr: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("../../../src/tasks/release-notes.js", () => ({
+  buildReleaseBody: vi.fn(),
+  buildFixedReleaseBody: vi.fn(),
+}));
 
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
@@ -310,6 +314,10 @@ import { writeVersionsForEcosystem } from "../../../src/manifest/write-versions.
 import { PluginRunner } from "../../../src/plugin/runner.js";
 import { createVersionPr } from "../../../src/tasks/create-version-pr.js";
 import { createGitHubRelease } from "../../../src/tasks/github-release.js";
+import {
+  buildReleaseBody,
+  buildFixedReleaseBody,
+} from "../../../src/tasks/release-notes.js";
 import {
   collectTokens,
   promptGhSecretsSync,
@@ -346,6 +354,8 @@ const mockedCratesDescriptor = (
 const mockedCollectTokens = vi.mocked(collectTokens);
 const mockedPromptGhSecretsSync = vi.mocked(promptGhSecretsSync);
 const mockedInjectTokensToEnv = vi.mocked(injectTokensToEnv);
+const mockedBuildReleaseBody = vi.mocked(buildReleaseBody);
+const mockedBuildFixedReleaseBody = vi.mocked(buildFixedReleaseBody);
 const mockedPrerequisitesCheckTask = vi.mocked(prerequisitesCheckTask);
 const mockedRequiredConditionsCheckTask = vi.mocked(
   requiredConditionsCheckTask,
@@ -450,6 +460,8 @@ beforeEach(() => {
 
   mockedExistsSync.mockReturnValue(false);
   mockedReadFileSync.mockReturnValue("");
+  mockedBuildReleaseBody.mockResolvedValue(undefined as any);
+  mockedBuildFixedReleaseBody.mockResolvedValue(undefined as any);
   mockedCreateGitHubRelease.mockResolvedValue({
     displayLabel: "pubm",
     version: "1.0.0",
@@ -487,14 +499,8 @@ describe("runner coverage scenarios", () => {
       ["packages/core", "1.2.0"],
       ["packages/pubm", "1.2.0"],
     ]);
-    mockedExistsSync.mockImplementation((filePath) =>
-      String(filePath)
-        .replace(/\\/g, "/")
-        .endsWith("packages/core/CHANGELOG.md"),
-    );
-    mockedReadFileSync.mockReturnValue("# Changelog");
-    mockedParseChangelogSection.mockImplementation((_content, version) =>
-      version === "1.2.0" ? "Added release notes" : undefined,
+    mockedBuildFixedReleaseBody.mockResolvedValue(
+      "## @pubm/core v1.2.0\n\nAdded release notes",
     );
 
     await run(
@@ -569,7 +575,7 @@ describe("runner coverage scenarios", () => {
         displayLabel: "@pubm/core",
         version: "1.2.0",
         tag: "v1.2.0",
-        changelogBody: expect.stringContaining("## @pubm/core v1.2.0"),
+        body: expect.stringContaining("## @pubm/core v1.2.0"),
       }),
     );
     expect(afterRelease).toHaveBeenCalledWith(
@@ -941,7 +947,7 @@ describe("runner coverage scenarios", () => {
         displayLabel: "@pubm/core",
         version: "1.2.0",
         tag: "v1.2.0",
-        changelogBody: undefined,
+        body: undefined,
       }),
     );
   });
@@ -1593,9 +1599,7 @@ describe("CI prepare pipeline", () => {
 
 describe("CI GitHub Release", () => {
   it("creates a single-mode release with root changelog", async () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue("# Changelog");
-    mockedParseChangelogSection.mockReturnValue("Single release notes");
+    mockedBuildReleaseBody.mockResolvedValue("Single release notes");
 
     await run(
       createOptions({
@@ -1659,7 +1663,7 @@ describe("CI GitHub Release", () => {
         displayLabel: "pubm",
         version: "4.0.0",
         tag: "v4.0.0",
-        changelogBody: "Single release notes",
+        body: "Single release notes",
       }),
     );
   });
@@ -1669,15 +1673,9 @@ describe("CI GitHub Release", () => {
       ["packages/core", "2.0.0"],
       ["packages/pubm", "2.1.0"],
     ]);
-    mockedExistsSync.mockImplementation((filePath) =>
-      String(filePath)
-        .replace(/\\/g, "/")
-        .endsWith("packages/core/CHANGELOG.md"),
-    );
-    mockedReadFileSync.mockReturnValue("# Changelog");
-    mockedParseChangelogSection.mockImplementation((_content, version) =>
-      version === "2.0.0" ? "Core release notes" : undefined,
-    );
+    mockedBuildReleaseBody
+      .mockResolvedValueOnce("Core release notes")
+      .mockResolvedValueOnce(undefined as any);
 
     await run(
       createOptions({
@@ -1756,7 +1754,7 @@ describe("CI GitHub Release", () => {
         displayLabel: "@pubm/core",
         version: "2.0.0",
         tag: "@pubm/core@2.0.0",
-        changelogBody: "Core release notes",
+        body: "Core release notes",
       }),
     );
     expect(mockedCreateGitHubRelease).toHaveBeenCalledWith(
@@ -1765,7 +1763,7 @@ describe("CI GitHub Release", () => {
         displayLabel: "pubm",
         version: "2.1.0",
         tag: "pubm@2.1.0",
-        changelogBody: undefined,
+        body: undefined,
       }),
     );
   });
@@ -5413,9 +5411,7 @@ describe("fixed mode release with tempDir cleanup", () => {
 
 describe("fixed mode release with changelog sections", () => {
   it("reads per-package changelog for fixed mode and joins sections", async () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue("# Changelog\n## 4.0.0\nChanges here");
-    mockedParseChangelogSection.mockReturnValue("Changes here");
+    mockedBuildFixedReleaseBody.mockResolvedValue("## pubm v4.0.0\n\nChanges here");
 
     await run(
       createOptions({
@@ -5480,7 +5476,7 @@ describe("fixed mode release with changelog sections", () => {
     expect(mockedCreateGitHubRelease).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
-        changelogBody: expect.stringContaining("## pubm v4.0.0"),
+        body: expect.stringContaining("## pubm v4.0.0"),
       }),
     );
   });

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -292,6 +292,7 @@ vi.mock("../../../src/tasks/create-version-pr.js", () => ({
 vi.mock("../../../src/tasks/release-notes.js", () => ({
   buildReleaseBody: vi.fn(),
   buildFixedReleaseBody: vi.fn(),
+  truncateForUrl: vi.fn(),
 }));
 
 import { existsSync, readFileSync, rmSync } from "node:fs";
@@ -317,6 +318,7 @@ import { createGitHubRelease } from "../../../src/tasks/github-release.js";
 import {
   buildReleaseBody,
   buildFixedReleaseBody,
+  truncateForUrl,
 } from "../../../src/tasks/release-notes.js";
 import {
   collectTokens,
@@ -356,6 +358,7 @@ const mockedPromptGhSecretsSync = vi.mocked(promptGhSecretsSync);
 const mockedInjectTokensToEnv = vi.mocked(injectTokensToEnv);
 const mockedBuildReleaseBody = vi.mocked(buildReleaseBody);
 const mockedBuildFixedReleaseBody = vi.mocked(buildFixedReleaseBody);
+const mockedTruncateForUrl = vi.mocked(truncateForUrl);
 const mockedPrerequisitesCheckTask = vi.mocked(prerequisitesCheckTask);
 const mockedRequiredConditionsCheckTask = vi.mocked(
   requiredConditionsCheckTask,
@@ -462,6 +465,7 @@ beforeEach(() => {
   mockedReadFileSync.mockReturnValue("");
   mockedBuildReleaseBody.mockResolvedValue(undefined as any);
   mockedBuildFixedReleaseBody.mockResolvedValue(undefined as any);
+  mockedTruncateForUrl.mockResolvedValue({ body: "", truncated: false, clipboardCopied: false });
   mockedCreateGitHubRelease.mockResolvedValue({
     displayLabel: "pubm",
     version: "1.0.0",
@@ -5592,7 +5596,7 @@ describe("independent release draft with previousTag fallback", () => {
     mockedResolveGitHubToken.mockReturnValueOnce(undefined as any);
     const pathVersions = new Map([["packages/core", "2.0.0"]]);
 
-    // Set up Git mock where previousTag returns empty string (falsy)
+    // Set up Git mock
     const gitInstance = {
       repository: vi.fn().mockResolvedValue("https://github.com/pubm/pubm"),
       previousTag: vi.fn().mockResolvedValue(""),
@@ -5605,6 +5609,8 @@ describe("independent release draft with previousTag fallback", () => {
     mockedGit.mockImplementation(function () {
       return gitInstance as any;
     } as any);
+
+    mockedBuildReleaseBody.mockResolvedValue("Release notes for fallback test");
 
     await run(
       createOptions({
@@ -5661,8 +5667,15 @@ describe("independent release draft with previousTag fallback", () => {
 
     await releaseDraftTask.task(ctx, task);
 
-    // firstCommit should have been called as fallback
-    expect(gitInstance.firstCommit).toHaveBeenCalled();
+    // buildReleaseBody now handles previousTag/firstCommit logic internally
+    expect(mockedBuildReleaseBody).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        pkgPath: "packages/core",
+        version: "2.0.0",
+        tag: "@pubm/core@2.0.0",
+      }),
+    );
     expect(mockedOpenUrl).toHaveBeenCalled();
   });
 });

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -316,15 +316,15 @@ import { PluginRunner } from "../../../src/plugin/runner.js";
 import { createVersionPr } from "../../../src/tasks/create-version-pr.js";
 import { createGitHubRelease } from "../../../src/tasks/github-release.js";
 import {
-  buildReleaseBody,
-  buildFixedReleaseBody,
-  truncateForUrl,
-} from "../../../src/tasks/release-notes.js";
-import {
   collectTokens,
   promptGhSecretsSync,
 } from "../../../src/tasks/preflight.js";
 import { prerequisitesCheckTask } from "../../../src/tasks/prerequisites-check.js";
+import {
+  buildFixedReleaseBody,
+  buildReleaseBody,
+  truncateForUrl,
+} from "../../../src/tasks/release-notes.js";
 import { requiredConditionsCheckTask } from "../../../src/tasks/required-conditions-check.js";
 import { run } from "../../../src/tasks/runner.js";
 import { exec } from "../../../src/utils/exec.js";
@@ -465,7 +465,11 @@ beforeEach(() => {
   mockedReadFileSync.mockReturnValue("");
   mockedBuildReleaseBody.mockResolvedValue(undefined as any);
   mockedBuildFixedReleaseBody.mockResolvedValue(undefined as any);
-  mockedTruncateForUrl.mockResolvedValue({ body: "", truncated: false, clipboardCopied: false });
+  mockedTruncateForUrl.mockResolvedValue({
+    body: "",
+    truncated: false,
+    clipboardCopied: false,
+  });
   mockedCreateGitHubRelease.mockResolvedValue({
     displayLabel: "pubm",
     version: "1.0.0",
@@ -5415,7 +5419,9 @@ describe("fixed mode release with tempDir cleanup", () => {
 
 describe("fixed mode release with changelog sections", () => {
   it("reads per-package changelog for fixed mode and joins sections", async () => {
-    mockedBuildFixedReleaseBody.mockResolvedValue("## pubm v4.0.0\n\nChanges here");
+    mockedBuildFixedReleaseBody.mockResolvedValue(
+      "## pubm v4.0.0\n\nChanges here",
+    );
 
     await run(
       createOptions({

--- a/packages/core/tests/unit/utils/clipboard.test.ts
+++ b/packages/core/tests/unit/utils/clipboard.test.ts
@@ -31,7 +31,10 @@ describe("copyToClipboard", () => {
     const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
     const result = await copyToClipboard("test text");
 
-    expect(spawn).toHaveBeenCalledWith(["pbcopy"], expect.objectContaining({ stdin: "pipe" }));
+    expect(spawn).toHaveBeenCalledWith(
+      ["pbcopy"],
+      expect.objectContaining({ stdin: "pipe" }),
+    );
     expect(mockStdin.write).toHaveBeenCalledWith("test text");
     expect(mockStdin.end).toHaveBeenCalled();
     expect(result).toBe(true);
@@ -50,7 +53,10 @@ describe("copyToClipboard", () => {
     const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
     const result = await copyToClipboard("test text");
 
-    expect(spawn).toHaveBeenCalledWith(["clip"], expect.objectContaining({ stdin: "pipe" }));
+    expect(spawn).toHaveBeenCalledWith(
+      ["clip"],
+      expect.objectContaining({ stdin: "pipe" }),
+    );
     expect(result).toBe(true);
   });
 
@@ -58,7 +64,8 @@ describe("copyToClipboard", () => {
     const mockStdin = { write: vi.fn(), end: vi.fn() };
     const failProc = { stdin: mockStdin, exited: Promise.resolve(1) };
     const successProc = { stdin: mockStdin, exited: Promise.resolve(0) };
-    const spawn = vi.fn()
+    const spawn = vi
+      .fn()
       .mockReturnValueOnce(failProc)
       .mockReturnValueOnce(successProc);
     vi.stubGlobal("Bun", { spawn });
@@ -71,7 +78,11 @@ describe("copyToClipboard", () => {
     const result = await copyToClipboard("test text");
 
     expect(spawn).toHaveBeenCalledTimes(2);
-    expect(spawn).toHaveBeenNthCalledWith(1, ["xclip", "-selection", "clipboard"], expect.any(Object));
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      ["xclip", "-selection", "clipboard"],
+      expect.any(Object),
+    );
     expect(spawn).toHaveBeenNthCalledWith(2, ["wl-copy"], expect.any(Object));
     expect(result).toBe(true);
   });

--- a/packages/core/tests/unit/utils/clipboard.test.ts
+++ b/packages/core/tests/unit/utils/clipboard.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("copyToClipboard", () => {
+  const originalPlatform = process.platform;
+  const originalBun = global.Bun;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+    global.Bun = originalBun;
+    vi.unstubAllGlobals();
+  });
+
+  it("uses pbcopy on macOS", async () => {
+    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    const mockProc = { stdin: mockStdin, exited: Promise.resolve(0) };
+    const spawn = vi.fn().mockReturnValue(mockProc);
+    vi.stubGlobal("Bun", { spawn });
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+
+    const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
+    const result = await copyToClipboard("test text");
+
+    expect(spawn).toHaveBeenCalledWith(["pbcopy"], expect.objectContaining({ stdin: "pipe" }));
+    expect(mockStdin.write).toHaveBeenCalledWith("test text");
+    expect(mockStdin.end).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it("uses clip on Windows", async () => {
+    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    const mockProc = { stdin: mockStdin, exited: Promise.resolve(0) };
+    const spawn = vi.fn().mockReturnValue(mockProc);
+    vi.stubGlobal("Bun", { spawn });
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+
+    const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
+    const result = await copyToClipboard("test text");
+
+    expect(spawn).toHaveBeenCalledWith(["clip"], expect.objectContaining({ stdin: "pipe" }));
+    expect(result).toBe(true);
+  });
+
+  it("tries xclip then wl-copy on Linux", async () => {
+    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    const failProc = { stdin: mockStdin, exited: Promise.resolve(1) };
+    const successProc = { stdin: mockStdin, exited: Promise.resolve(0) };
+    const spawn = vi.fn()
+      .mockReturnValueOnce(failProc)
+      .mockReturnValueOnce(successProc);
+    vi.stubGlobal("Bun", { spawn });
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
+    const result = await copyToClipboard("test text");
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(1, ["xclip", "-selection", "clipboard"], expect.any(Object));
+    expect(spawn).toHaveBeenNthCalledWith(2, ["wl-copy"], expect.any(Object));
+    expect(result).toBe(true);
+  });
+
+  it("returns false when all clipboard tools fail", async () => {
+    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    const failProc = { stdin: mockStdin, exited: Promise.resolve(1) };
+    const spawn = vi.fn().mockReturnValue(failProc);
+    vi.stubGlobal("Bun", { spawn });
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
+    const result = await copyToClipboard("test text");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when spawn throws", async () => {
+    const spawn = vi.fn().mockImplementation(() => {
+      throw new Error("command not found");
+    });
+    vi.stubGlobal("Bun", { spawn });
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+
+    const { copyToClipboard } = await import("../../../src/utils/clipboard.js");
+    const result = await copyToClipboard("test text");
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix browser draft release URL exceeding length limits when body is constructed from raw commits with full URLs, causing the GitHub page to fail to load
- Unify release note generation across API and browser draft paths with a shared `buildReleaseBody` function (CHANGELOG.md → conventional commits → raw commits priority chain)
- Add URL truncation with clipboard copy fallback when the draft URL exceeds 8,000 chars

## Changes

- **`release-notes.ts`** (new): `buildReleaseBody`, `buildFixedReleaseBody`, `renderReleaseNoteSections`, `truncateForUrl`
- **`clipboard.ts`** (new): `copyToClipboard` (pbcopy/clip/xclip/wl-copy)
- **`github-release.ts`**: Remove `formatReleaseNotes`, rename `changelogBody` → `body` (caller provides body directly)
- **`push-release.ts`**: Replace inline body construction in both API and browser draft paths
- **i18n**: Add clipboard/truncation messages to all 6 locales
- **Tests**: 41 unit tests (release-notes) + 5 (clipboard)

## Test plan

- [x] `bun run format` pass
- [x] `bun run typecheck` pass
- [x] `bun run test` — 2107 tests pass
- [x] `bun run coverage` — 95.84% statements, 90.32% branches, 95.74% functions, 96.28% lines