### PR TITLE
docs(pubm-plugin): add internals knowledge to publish-setup skill

### DIFF
--- a/plugins/pubm-plugin/skills/publish-setup/references/ci-templates.md
+++ b/plugins/pubm-plugin/skills/publish-setup/references/ci-templates.md
@@ -488,6 +488,144 @@ permissions:
 
 No additional secrets required; `GITHUB_TOKEN` is automatically available.
 
+## CI Patterns
+
+Advanced CI patterns for complex publishing scenarios. For basic trigger templates (tag-based, commit-based, manual), see the templates above.
+
+### Cross-Platform Matrix Build
+
+Build platform-specific binaries on native runners, collect artifacts, then publish from a single job.
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build binary
+        run: |
+          # Build for ${{ matrix.target }}...
+          # Output to dist/${{ matrix.target }}/
+
+      - name: Sign macOS binary
+        if: runner.os == 'macOS'
+        run: |
+          codesign --remove-signature dist/${{ matrix.target }}/binary
+          codesign -s - dist/${{ matrix.target }}/binary
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: dist/${{ matrix.target }}/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      # --- INSERT SETUP BLOCK FOR YOUR PACKAGE MANAGER ---
+
+      - name: Publish and release
+        run: <runner> pubm --mode ci --phase publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+```
+
+**Key points:**
+- macOS binaries **must** be signed on macOS runners using native `codesign`. `rcodesign` is no longer used.
+- The publish job downloads all artifacts into `dist/` where pubm's asset pipeline can resolve them via glob patterns.
+- Configure `releaseAssets` in `pubm.config.ts` to match the artifact directory structure.
+
+### pubm as CI Trigger
+
+Use local `--phase prepare` to control when releases happen, while CI handles the actual build and publish.
+
+```
+Developer                          CI
+   │                                │
+   ├─ pubm --phase prepare          │
+   │  ├─ runs tests                 │
+   │  ├─ runs build                 │
+   │  ├─ bumps versions             │
+   │  ├─ creates "Version Packages" │
+   │    commit + tags               │
+   │  └─ git push --follow-tags ────┤
+   │                                ├─ triggered by tag/commit
+   │                                ├─ checkout + setup
+   │                                ├─ build (possibly cross-platform)
+   │                                └─ pubm --mode ci --phase publish
+   │                                   ├─ publish to registries
+   │                                   └─ create GitHub Release
+```
+
+**When to use this pattern:**
+- You want manual control over release timing
+- CI needs to do platform-specific builds that can't run locally
+- You want local validation (tests, dry-run) before triggering CI
+
+**Local command:**
+```bash
+pubm --phase prepare
+```
+
+This runs tests, builds, bumps versions, creates the commit and tags, and pushes. The push triggers CI.
+
+### Platform Binary Signing in CI
+
+macOS binaries require code signing. Here's how to handle it in CI:
+
+**macOS runners (recommended):**
+```yaml
+      - name: Sign binary
+        if: runner.os == 'macOS'
+        run: |
+          codesign --remove-signature $BINARY_PATH
+          codesign -s - $BINARY_PATH
+```
+
+**Why `--remove-signature` first:** Some build tools embed a malformed signature. Removing it before re-signing ensures a clean ad-hoc signature.
+
+**Linux cross-compilation for macOS:**
+- Native `codesign` is not available on Linux
+- Build darwin binaries on macOS runners instead
+- If macOS runners are not available, the binaries will be unsigned and will be killed by Gatekeeper on macOS
+
+**Windows:** No code signing needed for basic distribution. Windows SmartScreen warnings can be suppressed with a proper code signing certificate (out of scope for pubm).
+
 ## Notes
 
 - **CI mode requires a phase flag.** `pubm --mode ci` alone is an error. Always specify `--phase prepare` or `--phase publish`.

--- a/plugins/pubm-plugin/skills/publish-setup/references/ci-templates.md
+++ b/plugins/pubm-plugin/skills/publish-setup/references/ci-templates.md
@@ -247,6 +247,8 @@ jobs:
 
 **Important:** This requires a **merge commit or fast-forward merge** strategy. Squash merges change the commit message and break the trigger.
 
+**Note:** For advanced monorepo patterns (cross-platform builds, platform binary signing), see the [CI Patterns](#ci-patterns) section below.
+
 ## Template: Manual Trigger (workflow_dispatch)
 
 ```yaml

--- a/plugins/pubm-plugin/skills/publish-setup/references/decision-guides.md
+++ b/plugins/pubm-plugin/skills/publish-setup/references/decision-guides.md
@@ -1,0 +1,125 @@
+# Setup Decision Guides
+
+Decision trees for common setup choices. Use these when recommending configuration during the publish-setup workflow.
+
+## CI Trigger Strategy
+
+Choose how CI publishes get triggered:
+
+| Project type | Recommended trigger | Why |
+|---|---|---|
+| Single package | Tag-based (`v*` push) | One tag = one version = one publish. Simple and reliable |
+| Monorepo (fixed versioning) | Tag-based (`v*` push) | All packages share one version, so one tag works |
+| Monorepo (independent versioning) | Commit-based ("Version Packages") | Multiple packages have different versions; no single tag represents the release |
+| Any | Manual (`workflow_dispatch`) | Useful as a supplementary trigger for re-runs or controlled releases |
+
+**Key constraint:** Commit-based triggers require **merge commit** or **fast-forward merge** strategy. Squash merges rewrite the commit message and break the `startsWith(github.event.head_commit.message, 'Version Packages')` condition.
+
+## Config File Necessity
+
+`pubm.config.ts` is optional. pubm auto-detects packages, ecosystems, and registries.
+
+### When you do NOT need a config file
+
+- Single-ecosystem project (JS-only or Rust-only)
+- Default registries are correct (npm+jsr for JS, crates for Rust)
+- No plugins needed
+- Default build/test commands from package manifest are sufficient
+
+### When you DO need a config file
+
+| Scenario | Config needed |
+|---|---|
+| Override detected registries (e.g., npm only, skip jsr) | `packages[].registries` |
+| Use any plugin (brew, externalVersionSync, custom) | `plugins` |
+| Custom build or test commands | `packages[].build` or `packages[].test` |
+| Private registry | `packages[].registries` with URL |
+| Multi-ecosystem directory (Cargo.toml + package.json) | `packages[].ecosystem` |
+| Monorepo with non-standard package paths | `packages[].path` |
+| Release assets / platform binaries | `releaseAssets` |
+
+**Rule of thumb:** If `pubm inspect packages` shows the correct packages with correct registries, you don't need a config file.
+
+## Phase Strategy
+
+How to split work between local and CI:
+
+### Option A: Local standalone (no CI)
+
+```bash
+pubm  # runs both prepare and publish locally
+```
+
+**Best for:** Simple projects, single developer, no cross-platform builds needed.
+
+### Option B: Prepare local + Publish in CI
+
+```bash
+# Local: runs tests, builds, bumps versions, creates tags, pushes
+pubm --phase prepare
+
+# CI: triggered by tag/commit, publishes to registries
+pubm --mode ci --phase publish
+```
+
+**Best for:** Most projects. Version control stays local, publishing is automated and reproducible.
+
+### Option C: Full CI automation
+
+```bash
+# CI prepare job: triggered by changeset merge
+pubm --mode ci --phase prepare
+
+# CI publish job: triggered by version commit/tag
+pubm --mode ci --phase publish
+```
+
+**Best for:** Teams with strict release processes, projects using changesets with automated version PRs.
+
+### Decision flow
+
+1. Do you need cross-platform builds? → **Option B or C** (CI handles the build matrix)
+2. Do you use changesets with a team? → **Option C** (fully automated)
+3. Solo developer, simple project? → **Option A** (local is fine)
+4. Default recommendation → **Option B** (balance of control and automation)
+
+## Multi-Ecosystem Projects
+
+When a directory contains manifests for multiple ecosystems (e.g., `Cargo.toml` + `package.json`):
+
+### The problem
+
+pubm checks Rust first, then JavaScript. Only one ecosystem is detected per directory. If both `Cargo.toml` and `package.json` exist, Rust wins and JavaScript is ignored.
+
+### Solution 1: Explicit ecosystem in config
+
+```typescript
+import { defineConfig } from 'pubm';
+
+export default defineConfig({
+  packages: [
+    {
+      path: '.',
+      ecosystem: 'js',
+      registries: ['npm'],
+    },
+    {
+      path: '.',
+      ecosystem: 'rust',
+      registries: ['crates'],
+    },
+  ],
+});
+```
+
+### Solution 2: Separate directories
+
+Organize Rust and JS code in separate directories so each is detected independently:
+
+```
+packages/
+  my-lib/          # package.json → JS detected
+  my-lib-native/   # Cargo.toml → Rust detected
+```
+
+**Recommendation:** Solution 1 if the project is already structured with both manifests at the root. Solution 2 for new projects or when restructuring is feasible.

--- a/plugins/pubm-plugin/skills/publish-setup/references/internals.md
+++ b/plugins/pubm-plugin/skills/publish-setup/references/internals.md
@@ -1,0 +1,150 @@
+# pubm Internals
+
+Behavioral summary of pubm's internal mechanics. Use this to understand how pubm works when diagnosing issues or making setup recommendations.
+
+## Release Pipeline
+
+pubm executes phases in this order:
+
+| Step | Phase | What happens |
+|------|-------|-------------|
+| Test | prepare | Runs test scripts defined in config or package manifest |
+| Build | prepare | Runs build scripts defined in config or package manifest |
+| Version | prepare | Bumps versions, writes changelogs, creates commit and tags |
+| Dry-Run | prepare | Validates publish would succeed without actually publishing |
+| Push | prepare | Pushes commit and tags to remote |
+| Publish | publish | Publishes to all configured registries |
+| Release | publish | Creates GitHub Releases with assets |
+
+## Phases
+
+### Prepare vs Publish
+
+| | Prepare | Publish |
+|---|---|---|
+| **Command** | `pubm --phase prepare` | `pubm --phase publish` |
+| **Does** | test, build, version bump, dry-run validation, git push | registry publish, GitHub Release |
+| **When omitted** | Both phases run (local default) | Both phases run (local default) |
+| **CI requirement** | Must specify exactly one phase | Must specify exactly one phase |
+
+Running locally without `--phase` executes both phases sequentially. In CI mode (`--mode ci`), omitting `--phase` is an error.
+
+### Common CI pattern
+
+1. Run `pubm --phase prepare` locally — runs tests, builds, bumps versions, creates tags, pushes
+2. Tag/commit push triggers CI workflow
+3. CI runs `pubm --mode ci --phase publish` — publishes and creates releases
+
+## Version Phase
+
+### Commit
+
+All version changes are committed in a single commit with the message **"Version Packages"**, followed by a summary of bumped packages and versions.
+
+### Tags
+
+Tag format depends on versioning mode:
+
+| Mode | Tag format | Example |
+|------|-----------|---------|
+| Single | `v{version}` | `v1.2.3` |
+| Fixed | `v{version}` | `v1.2.3` |
+| Independent | `{packageName}@{version}` | `@pubm/core@1.2.3` |
+
+Tags are annotated (`git tag -a`). If a tag already exists, pubm prompts for deletion (local) or errors (CI).
+
+### Changelog
+
+- **Single/Fixed mode:** Single `CHANGELOG.md` at the project root
+- **Independent mode:** Per-package `CHANGELOG.md` in each package directory
+
+Changelogs are generated from changesets when changesets are configured.
+
+## Push Phase
+
+### Primary path
+
+```bash
+git push --follow-tags
+```
+
+Pushes the version commit and all reachable annotated tags in one operation.
+
+### PR fallback
+
+If direct push fails (e.g., protected branch rules), pubm automatically:
+
+1. Creates a branch: `pubm/version-packages-{timestamp}`
+2. Pushes the branch with `git push -u origin {branch} --follow-tags`
+3. Creates a PR via GitHub API with changelog details
+4. Switches back to the base branch
+
+No manual intervention needed — the PR fallback is automatic.
+
+## Ecosystem Detection
+
+pubm detects the ecosystem for each package directory by checking manifest files in priority order:
+
+| Priority | Ecosystem | Detected by | Default registries |
+|----------|-----------|-------------|-------------------|
+| 1 | Rust | `Cargo.toml` exists | `crates` |
+| 2 | JavaScript | `package.json`, `deno.json`, or `deno.jsonc` exists | `npm`, `jsr` |
+
+**First match wins.** Only one ecosystem is detected per directory. If a directory has both `Cargo.toml` and `package.json`, Rust is detected. To override, set `ecosystem: 'js'` (or `'rust'`) explicitly in the package config.
+
+## Workspace Protocol Resolution
+
+During publish, pubm resolves workspace protocol references to concrete versions:
+
+| Protocol | Resolved to |
+|----------|------------|
+| `workspace:*` | Exact version (e.g., `1.2.3`) |
+| `workspace:^` | Caret range (e.g., `^1.2.3`) |
+| `workspace:~` | Tilde range (e.g., `~1.2.3`) |
+
+Local manifests are restored to their original `workspace:*` form after publishing.
+
+## Platform Binary Distribution
+
+pubm itself uses a platform-specific binary distribution pattern:
+
+### Architecture
+
+- **Main package** (`pubm`): Contains `cli.cjs` launcher and `postinstall.cjs`
+- **Platform packages** (`@pubm/darwin-arm64`, `@pubm/linux-x64`, etc.): Listed as `optionalDependencies`, each contains a compiled binary for one platform
+- **12 platform variants**: darwin (arm64, x64, x64-baseline), linux (arm64, arm64-musl, x64, x64-baseline, x64-musl, x64-musl-baseline), windows (arm64, x64, x64-baseline)
+
+### How it works
+
+1. `npm install pubm` installs only the platform package matching the current OS/arch
+2. `postinstall.cjs` resolves the correct binary and caches it at `bin/.pubm` for fast startup
+3. `cli.cjs` spawns the cached binary, falling back to node_modules lookup if cache is missing
+4. On x64, runtime AVX2 detection selects between regular and `-baseline` variants
+5. On Linux, musl/glibc detection selects the correct libc variant
+
+### Code signing
+
+macOS binaries require ad-hoc code signing to avoid Gatekeeper SIGKILL:
+
+```bash
+codesign --remove-signature <binary>
+codesign -s - <binary>
+```
+
+**Without signing, macOS kills the binary with SIGKILL, which is silently swallowed as exit code 0 by the Node.js launcher.** This makes the failure invisible — `inspect packages` produces no output with no error message.
+
+## Asset Pipeline
+
+For projects distributing platform binaries via GitHub Releases, pubm provides a 5-stage asset pipeline:
+
+| Stage | Purpose |
+|-------|---------|
+| Resolve | Match files via glob patterns with `{platform}`, `{os}`, `{arch}` captures |
+| Transform | Plugin hook to modify or multiply assets |
+| Compress | Auto-select format (tar.gz, zip, tar.xz, tar.zst) based on platform OS |
+| Name | Apply naming template: `{filename}-{platform}` default |
+| Checksum | Generate SHA256 checksums |
+
+Glob patterns support capture variables: `dist/{platform}/binary` or `dist/{os}/{arch}/binary`. If no explicit captures are used, pubm auto-parses platform info from path segments.
+
+Compression format priority: per-file override > per-group > global config > OS-based auto-detect.

--- a/plugins/pubm-plugin/skills/publish-setup/references/troubleshooting.md
+++ b/plugins/pubm-plugin/skills/publish-setup/references/troubleshooting.md
@@ -1,0 +1,176 @@
+# Troubleshooting
+
+Common issues encountered during pubm setup and publishing, organized by category. Each entry lists the symptom, cause, and solution.
+
+## Binary / Signing
+
+### macOS binary killed immediately (SIGKILL)
+
+**Symptom:** Binary exits silently with code 0, or `inspect packages` produces no output.
+
+**Cause:** macOS Gatekeeper kills unsigned binaries with SIGKILL. The Node.js `cli.cjs` launcher swallows this signal as exit code 0, hiding the failure.
+
+**Diagnosis:**
+```bash
+# Check if binary is signed
+codesign -dv /path/to/binary
+
+# Run binary directly (not through cli.cjs) to see the signal
+./node_modules/@pubm/darwin-arm64/pubm
+```
+
+**Solution:**
+```bash
+codesign --remove-signature /path/to/binary
+codesign -s - /path/to/binary
+```
+
+### Cross-compiled darwin binary fails
+
+**Symptom:** Binary built on Linux for macOS (darwin) crashes or is killed on macOS.
+
+**Cause:** Linux builds cannot produce ad-hoc signed macOS binaries. macOS requires code signatures even for ad-hoc (`-s -`) signing.
+
+**Solution:** Build darwin binaries on a macOS runner. `rcodesign` was previously used for cross-platform signing but has been dropped in favor of native `codesign` on macOS runners.
+
+```yaml
+# CI: use macOS runner for darwin builds
+jobs:
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - run: |
+          # Build binary...
+          codesign --remove-signature $BINARY
+          codesign -s - $BINARY
+```
+
+### `inspect packages` produces no output
+
+**Symptom:** `pubm inspect packages` returns immediately with no output and no error.
+
+**Cause:** The underlying binary is failing silently. Most commonly caused by unsigned macOS binaries (see above).
+
+**Diagnosis:** Run the platform binary directly instead of through `cli.cjs`:
+```bash
+./node_modules/@pubm/darwin-arm64/pubm inspect packages
+```
+
+If it shows `Killed: 9`, the binary is unsigned.
+
+## Ecosystem / Config
+
+### Multi-ecosystem root shows empty name/version
+
+**Symptom:** `pubm inspect packages` shows a package with empty name or version at the project root.
+
+**Cause:** The root directory has both `Cargo.toml` and `package.json`. Rust is detected first (higher priority), and the Rust manifest may not have the expected name/version fields for your JS project.
+
+**Solution:** Set the ecosystem explicitly in `pubm.config.ts`:
+```typescript
+import { defineConfig } from 'pubm';
+
+export default defineConfig({
+  packages: [
+    {
+      path: '.',
+      ecosystem: 'js',
+      registries: ['npm'],
+    },
+  ],
+});
+```
+
+### `workspace:*` still in package.json after publish
+
+**Symptom:** After publishing, `package.json` still shows `workspace:*` in dependencies.
+
+**Cause:** This is expected behavior. pubm temporarily resolves `workspace:*` to concrete versions during the publish operation, then restores the original `workspace:*` references. The published package on the registry has concrete versions.
+
+**Solution:** No action needed. Check the published package on the registry to confirm versions were resolved correctly.
+
+## Git / CI
+
+### "Version Packages" commit trigger not firing
+
+**Symptom:** The CI workflow with `startsWith(github.event.head_commit.message, 'Version Packages')` never triggers.
+
+**Cause:** Squash merges rewrite the commit message. The "Version Packages" commit message is lost.
+
+**Solution:** Use **merge commit** or **fast-forward merge** strategy for the version PR. Do not use squash merge.
+
+### `git push --follow-tags` rejected
+
+**Symptom:** Push fails with a GitHub API error (GH006) about branch protection.
+
+**Cause:** The target branch has push protection rules that prevent direct pushes.
+
+**Solution:** pubm handles this automatically with a PR fallback. It creates a `pubm/version-packages-{timestamp}` branch, pushes there, and opens a PR via GitHub API. No manual action needed.
+
+If you want to avoid the PR fallback, ensure the pushing user/token has bypass permissions on the branch protection rules.
+
+### CI fails with "phase required" error
+
+**Symptom:** `pubm --mode ci` fails with an error about requiring a phase flag.
+
+**Cause:** CI mode requires exactly one of `--phase prepare` or `--phase publish`. Omitting the phase flag is only valid for local (non-CI) runs.
+
+**Solution:** Add the appropriate phase flag:
+```bash
+# For the publish step in CI
+pubm --mode ci --phase publish
+
+# For the prepare/validation step in CI
+pubm --mode ci --phase prepare
+```
+
+### Tag already exists
+
+**Symptom:** Version phase fails because a tag (e.g., `v1.2.3`) already exists.
+
+**Cause:** A previous release attempt created the tag but failed before completing. Or the version was already released.
+
+**Solution:**
+- **Local:** pubm prompts whether to delete the existing tag
+- **CI:** This is an error. Delete the tag manually before retrying:
+  ```bash
+  git tag -d v1.2.3
+  git push origin :refs/tags/v1.2.3
+  ```
+
+### Changeset check failing on PRs
+
+**Symptom:** The changeset check GitHub Action fails even though changes are user-facing.
+
+**Cause:** No `.pubm/changesets/*.md` file was added to the PR.
+
+**Solution:** Add a changeset:
+```bash
+pubm changesets add --packages <package-path> --bump <patch|minor|major> --message "description"
+```
+
+Or apply the `no-changeset` label to the PR if the change doesn't need a changeset (e.g., docs-only, CI config).
+
+## Rollback
+
+### What gets rolled back on failure
+
+pubm registers rollback actions in LIFO (last-in, first-out) order. On failure:
+
+1. Remote tags are deleted
+2. Local commit is reverted
+3. If PR fallback was used: PR is closed and branch is deleted
+4. Local manifest backups are restored (versions, changelogs, changesets)
+
+### Partial registry publish failure
+
+**Symptom:** Publishing succeeded on some registries but failed on others.
+
+**Cause:** Registry publishes run concurrently. If one fails after others succeed, the successful publishes cannot always be undone.
+
+**Solution:** This requires manual intervention:
+- **npm:** `npm unpublish` has a 72-hour window, but only for packages with no dependents
+- **crates.io:** Published crates cannot be unpublished, only yanked (`cargo yank`)
+- **jsr:** Check jsr.io for unpublish/deprecation options
+
+Re-run `pubm --mode ci --phase publish` after fixing the root cause — already-published versions are automatically skipped.


### PR DESCRIPTION
## Summary

Closes #16

- Add `references/internals.md` — pubm internal behavior summary (release pipeline, phases, ecosystem detection, platform binaries, asset pipeline)
- Add `references/troubleshooting.md` — problem diagnosis guide (binary signing, ecosystem config, Git/CI, rollback)
- Add `references/decision-guides.md` — setup decision trees (CI trigger strategy, config necessity, phase strategy, multi-ecosystem)
- Expand `references/ci-templates.md` — advanced CI patterns (cross-platform matrix build, pubm as CI trigger, platform binary signing)

## Test plan
- [ ] Verify all 4 new/modified reference files exist in `plugins/pubm-plugin/skills/publish-setup/references/`
- [ ] Verify SKILL.md is unchanged
- [ ] Verify existing ci-templates.md content is preserved (no deletions)
- [ ] Spot-check technical accuracy against pubm core source