### PR TITLE
feat: support multi-ecosystem detection in a single directory

### DIFF
--- a/packages/core/src/changeset/changelog.ts
+++ b/packages/core/src/changeset/changelog.ts
@@ -1,3 +1,4 @@
+import { packageKey } from "../utils/package-key.js";
 import type { BumpType, Changeset } from "./parser.js";
 
 export { writeChangelogToFile } from "../changelog/file.js";
@@ -74,13 +75,16 @@ export function deduplicateEntries(
 
 export function buildChangelogEntries(
   changesets: Changeset[],
-  packagePath: string,
+  targetKey: string,
 ): ChangelogEntry[] {
   const entries: ChangelogEntry[] = [];
 
   for (const changeset of changesets) {
     for (const release of changeset.releases) {
-      if (release.path === packagePath) {
+      const releaseKey = release.ecosystem
+        ? packageKey({ path: release.path, ecosystem: release.ecosystem })
+        : release.path;
+      if (releaseKey === targetKey) {
         entries.push({
           summary: changeset.summary,
           type: release.type,

--- a/packages/core/src/changeset/changelog.ts
+++ b/packages/core/src/changeset/changelog.ts
@@ -84,7 +84,7 @@ export function buildChangelogEntries(
       const releaseKey = release.ecosystem
         ? packageKey({ path: release.path, ecosystem: release.ecosystem })
         : release.path;
-      if (releaseKey === targetKey) {
+      if (releaseKey === targetKey || release.path === targetKey) {
         entries.push({
           summary: changeset.summary,
           type: release.type,

--- a/packages/core/src/changeset/parser.ts
+++ b/packages/core/src/changeset/parser.ts
@@ -1,9 +1,11 @@
 import { parse as parseYaml } from "yaml";
+import type { EcosystemKey } from "../ecosystem/catalog.js";
 
 export type BumpType = "patch" | "minor" | "major";
 
 export interface Release {
   path: string;
+  ecosystem?: EcosystemKey;
   type: BumpType;
 }
 
@@ -43,8 +45,21 @@ export function parseChangeset(
           `Invalid bump type "${type}" for package "${key}" in "${fileName}". Expected: patch, minor, or major.`,
         );
       }
-      const path = resolveKey ? resolveKey(key) : key;
-      releases.push({ path, type: type as BumpType });
+      const resolvedKey = resolveKey ? resolveKey(key) : key;
+
+      // Parse path::ecosystem format
+      const separatorIndex = resolvedKey.lastIndexOf("::");
+      let releasePath: string;
+      let ecosystem: EcosystemKey | undefined;
+      if (separatorIndex !== -1) {
+        releasePath = resolvedKey.slice(0, separatorIndex);
+        ecosystem = resolvedKey.slice(separatorIndex + 2);
+      } else {
+        releasePath = resolvedKey;
+        ecosystem = undefined;
+      }
+
+      releases.push({ path: releasePath, ecosystem, type: type as BumpType });
     }
   }
 

--- a/packages/core/src/changeset/parser.ts
+++ b/packages/core/src/changeset/parser.ts
@@ -54,6 +54,11 @@ export function parseChangeset(
       if (separatorIndex !== -1) {
         releasePath = resolvedKey.slice(0, separatorIndex);
         ecosystem = resolvedKey.slice(separatorIndex + 2);
+        if (!releasePath || !ecosystem) {
+          throw new Error(
+            `Invalid package key "${resolvedKey}" in "${fileName}". Expected "path::ecosystem" with non-empty path and ecosystem.`,
+          );
+        }
       } else {
         releasePath = resolvedKey;
         ecosystem = undefined;

--- a/packages/core/src/changeset/resolve.ts
+++ b/packages/core/src/changeset/resolve.ts
@@ -4,19 +4,32 @@ import { packageKey } from "../utils/package-key.js";
 export function createKeyResolver(
   packages: { name: string; path: string; ecosystem: EcosystemKey }[],
 ): (key: string) => string {
-  const nameToKey = new Map(packages.map((p) => [p.name, packageKey(p)]));
   const validKeys = new Set(packages.map((p) => packageKey(p)));
   const pathEcosystems = new Map<string, EcosystemKey[]>();
+  const nameEcosystems = new Map<string, EcosystemKey[]>();
   for (const p of packages) {
-    const existing = pathEcosystems.get(p.path) ?? [];
-    existing.push(p.ecosystem);
-    pathEcosystems.set(p.path, existing);
+    const existingPath = pathEcosystems.get(p.path) ?? [];
+    existingPath.push(p.ecosystem);
+    pathEcosystems.set(p.path, existingPath);
+
+    const existingName = nameEcosystems.get(p.name) ?? [];
+    existingName.push(p.ecosystem);
+    nameEcosystems.set(p.name, existingName);
   }
 
   return (key: string): string => {
     if (validKeys.has(key)) return key;
-    const fromName = nameToKey.get(key);
-    if (fromName) return fromName;
+    const nameEcos = nameEcosystems.get(key);
+    if (nameEcos) {
+      if (nameEcos.length === 1) {
+        const pkg = packages.find((p) => p.name === key);
+        if (pkg) return packageKey(pkg);
+      }
+      throw new Error(
+        `Ambiguous changeset key "${key}": name is shared across ecosystems (${nameEcos.join(", ")}). ` +
+          `Use the path::ecosystem format to specify.`,
+      );
+    }
     const ecosystems = pathEcosystems.get(key);
     if (ecosystems) {
       if (ecosystems.length === 1) {

--- a/packages/core/src/changeset/resolve.ts
+++ b/packages/core/src/changeset/resolve.ts
@@ -9,11 +9,11 @@ export function createKeyResolver(
   const nameEcosystems = new Map<string, EcosystemKey[]>();
   for (const p of packages) {
     const existingPath = pathEcosystems.get(p.path) ?? [];
-    existingPath.push(p.ecosystem);
+    if (!existingPath.includes(p.ecosystem)) existingPath.push(p.ecosystem);
     pathEcosystems.set(p.path, existingPath);
 
     const existingName = nameEcosystems.get(p.name) ?? [];
-    existingName.push(p.ecosystem);
+    if (!existingName.includes(p.ecosystem)) existingName.push(p.ecosystem);
     nameEcosystems.set(p.name, existingName);
   }
 

--- a/packages/core/src/changeset/resolve.ts
+++ b/packages/core/src/changeset/resolve.ts
@@ -19,6 +19,16 @@ export function createKeyResolver(
 
   return (key: string): string => {
     if (validKeys.has(key)) return key;
+    const ecosystems = pathEcosystems.get(key);
+    if (ecosystems) {
+      if (ecosystems.length === 1) {
+        return `${key}::${ecosystems[0]}`;
+      }
+      throw new Error(
+        `Ambiguous changeset key "${key}": directory contains multiple ecosystems (${ecosystems.join(", ")}). ` +
+          `Use "${key}::${ecosystems[0]}" or "${key}::${ecosystems[1]}" to specify.`,
+      );
+    }
     const nameEcos = nameEcosystems.get(key);
     if (nameEcos) {
       if (nameEcos.length === 1) {
@@ -28,16 +38,6 @@ export function createKeyResolver(
       throw new Error(
         `Ambiguous changeset key "${key}": name is shared across ecosystems (${nameEcos.join(", ")}). ` +
           `Use the path::ecosystem format to specify.`,
-      );
-    }
-    const ecosystems = pathEcosystems.get(key);
-    if (ecosystems) {
-      if (ecosystems.length === 1) {
-        return `${key}::${ecosystems[0]}`;
-      }
-      throw new Error(
-        `Ambiguous changeset key "${key}": directory contains multiple ecosystems (${ecosystems.join(", ")}). ` +
-          `Use "${key}::${ecosystems[0]}" or "${key}::${ecosystems[1]}" to specify.`,
       );
     }
     return key;

--- a/packages/core/src/changeset/resolve.ts
+++ b/packages/core/src/changeset/resolve.ts
@@ -4,9 +4,7 @@ import { packageKey } from "../utils/package-key.js";
 export function createKeyResolver(
   packages: { name: string; path: string; ecosystem: EcosystemKey }[],
 ): (key: string) => string {
-  const nameToKey = new Map(
-    packages.map((p) => [p.name, packageKey(p)]),
-  );
+  const nameToKey = new Map(packages.map((p) => [p.name, packageKey(p)]));
   const validKeys = new Set(packages.map((p) => packageKey(p)));
   const pathEcosystems = new Map<string, EcosystemKey[]>();
   for (const p of packages) {

--- a/packages/core/src/changeset/resolve.ts
+++ b/packages/core/src/changeset/resolve.ts
@@ -1,15 +1,34 @@
-import type { ResolvedPackageConfig } from "../config/types.js";
+import type { EcosystemKey } from "../ecosystem/catalog.js";
+import { packageKey } from "../utils/package-key.js";
 
 export function createKeyResolver(
-  packages: Pick<ResolvedPackageConfig, "name" | "path">[],
+  packages: { name: string; path: string; ecosystem: EcosystemKey }[],
 ): (key: string) => string {
-  const nameToPath = new Map(packages.map((p) => [p.name, p.path]));
-  const validPaths = new Set(packages.map((p) => p.path));
+  const nameToKey = new Map(
+    packages.map((p) => [p.name, packageKey(p)]),
+  );
+  const validKeys = new Set(packages.map((p) => packageKey(p)));
+  const pathEcosystems = new Map<string, EcosystemKey[]>();
+  for (const p of packages) {
+    const existing = pathEcosystems.get(p.path) ?? [];
+    existing.push(p.ecosystem);
+    pathEcosystems.set(p.path, existing);
+  }
 
   return (key: string): string => {
-    if (validPaths.has(key)) return key;
-    const resolved = nameToPath.get(key);
-    if (resolved) return resolved;
+    if (validKeys.has(key)) return key;
+    const fromName = nameToKey.get(key);
+    if (fromName) return fromName;
+    const ecosystems = pathEcosystems.get(key);
+    if (ecosystems) {
+      if (ecosystems.length === 1) {
+        return `${key}::${ecosystems[0]}`;
+      }
+      throw new Error(
+        `Ambiguous changeset key "${key}": directory contains multiple ecosystems (${ecosystems.join(", ")}). ` +
+          `Use "${key}::${ecosystems[0]}" or "${key}::${ecosystems[1]}" to specify.`,
+      );
+    }
     return key;
   };
 }

--- a/packages/core/src/changeset/status.ts
+++ b/packages/core/src/changeset/status.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { packageKey } from "../utils/package-key.js";
 import { maxBump } from "./bump-utils.js";
 import type { BumpType, Changeset } from "./parser.js";
 import { readChangesets } from "./reader.js";
@@ -24,14 +25,17 @@ export function getStatus(
 
   for (const changeset of changesets) {
     for (const release of changeset.releases) {
-      const existing = packages.get(release.path);
+      const key = release.ecosystem
+        ? packageKey({ path: release.path, ecosystem: release.ecosystem })
+        : release.path;
+      const existing = packages.get(key);
 
       if (existing) {
         existing.bumpType = maxBump(existing.bumpType, release.type);
         existing.changesetCount += 1;
         existing.summaries.push(changeset.summary);
       } else {
-        packages.set(release.path, {
+        packages.set(key, {
           bumpType: release.type,
           changesetCount: 1,
           summaries: [changeset.summary],

--- a/packages/core/src/changeset/version.ts
+++ b/packages/core/src/changeset/version.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { inc } from "semver";
+import { packageKey } from "../utils/package-key.js";
 import { maxBump } from "./bump-utils.js";
 import type { BumpType } from "./parser.js";
 import { readChangesets } from "./reader.js";
@@ -20,13 +21,16 @@ export function calculateVersionBumps(
 
   for (const changeset of changesets) {
     for (const release of changeset.releases) {
-      if (!currentVersions.has(release.path)) continue;
+      const key = release.ecosystem
+        ? packageKey({ path: release.path, ecosystem: release.ecosystem })
+        : release.path;
+      if (!currentVersions.has(key)) continue;
 
-      const existing = bumpTypes.get(release.path);
+      const existing = bumpTypes.get(key);
       if (existing) {
-        bumpTypes.set(release.path, maxBump(existing, release.type));
+        bumpTypes.set(key, maxBump(existing, release.type));
       } else {
-        bumpTypes.set(release.path, release.type);
+        bumpTypes.set(key, release.type);
       }
     }
   }

--- a/packages/core/src/changeset/writer.ts
+++ b/packages/core/src/changeset/writer.ts
@@ -90,7 +90,10 @@ export function generateChangesetContent(
   if (releases.length > 0) {
     const yamlObj: Record<string, string> = {};
     for (const release of releases) {
-      yamlObj[release.path] = release.type;
+      const key = release.ecosystem
+        ? `${release.path}::${release.ecosystem}`
+        : release.path;
+      yamlObj[key] = release.type;
     }
     content += stringifyYaml(yamlObj);
   }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,5 +1,6 @@
 import type { CompressOption, ReleaseAssetEntry } from "../assets/types.js";
 import type { BumpType } from "../changeset/parser.js";
+import type { EcosystemKey } from "../ecosystem/catalog.js";
 import type { PubmPlugin } from "../plugin/types.js";
 import type { RegistryType } from "../types/options.js";
 
@@ -26,11 +27,12 @@ export interface PackageConfig {
 }
 
 export interface ResolvedPackageConfig
-  extends Omit<PackageConfig, "registries"> {
+  extends Omit<PackageConfig, "registries" | "ecosystem"> {
   name: string;
   version: string;
   dependencies: string[];
   registries: RegistryType[];
+  ecosystem: EcosystemKey;
   registryVersions?: Map<RegistryType, string>;
 }
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -8,7 +8,7 @@ import { RollbackTracker } from "./utils/rollback.js";
 export interface SingleVersionPlan {
   mode: "single";
   version: string;
-  packagePath: string;
+  packageKey: string;
 }
 
 export interface FixedVersionPlan {
@@ -44,13 +44,13 @@ export function resolveVersion(
 
 export function getPackageVersion(
   ctx: PubmContext,
-  packagePath: string,
+  key: string,
 ): string {
   const plan = ctx.runtime.versionPlan;
   if (plan) {
     if (plan.mode === "single") return plan.version;
     if (plan.mode === "fixed") return plan.version;
-    return plan.packages.get(packagePath) ?? "";
+    return plan.packages.get(key) ?? "";
   }
   return "";
 }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -42,10 +42,7 @@ export function resolveVersion(
   return picker(plan.packages);
 }
 
-export function getPackageVersion(
-  ctx: PubmContext,
-  key: string,
-): string {
+export function getPackageVersion(ctx: PubmContext, key: string): string {
   const plan = ctx.runtime.versionPlan;
   if (plan) {
     if (plan.mode === "single") return plan.version;

--- a/packages/core/src/ecosystem/catalog.ts
+++ b/packages/core/src/ecosystem/catalog.ts
@@ -24,13 +24,14 @@ export class EcosystemCatalog {
     return this.descriptors.get(key);
   }
 
-  async detect(packagePath: string): Promise<EcosystemDescriptor | null> {
+  async detectAll(packagePath: string): Promise<EcosystemDescriptor[]> {
+    const results: EcosystemDescriptor[] = [];
     for (const descriptor of this.descriptors.values()) {
       if (await descriptor.detect(packagePath)) {
-        return descriptor;
+        results.push(descriptor);
       }
     }
-    return null;
+    return results;
   }
 
   all(): EcosystemDescriptor[] {

--- a/packages/core/src/ecosystem/index.ts
+++ b/packages/core/src/ecosystem/index.ts
@@ -4,9 +4,9 @@ import type { Ecosystem } from "./ecosystem.js";
 export async function detectEcosystem(
   packagePath: string,
 ): Promise<Ecosystem | null> {
-  const detected = await ecosystemCatalog.detect(packagePath);
-  if (detected) {
-    return new detected.ecosystemClass(packagePath);
+  const detected = await ecosystemCatalog.detectAll(packagePath);
+  if (detected.length > 0) {
+    return new detected[0].ecosystemClass(packagePath);
   }
 
   return null;

--- a/packages/core/src/ecosystem/index.ts
+++ b/packages/core/src/ecosystem/index.ts
@@ -1,6 +1,12 @@
 import { ecosystemCatalog } from "./catalog.js";
 import type { Ecosystem } from "./ecosystem.js";
 
+/**
+ * Detects the ecosystem for a single package path, returning only the first
+ * detected ecosystem. This is a convenience API for single-ecosystem packages.
+ * For packages that may belong to multiple ecosystems, use
+ * `ecosystemCatalog.detectAll()` instead.
+ */
 export async function detectEcosystem(
   packagePath: string,
 ): Promise<Ecosystem | null> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -236,6 +236,7 @@ export { exec } from "./utils/exec.js";
 export type { GitHubTokenResult } from "./utils/github-token.js";
 export { resolveGitHubToken, saveGitHubToken } from "./utils/github-token.js";
 export { notifyNewVersion } from "./utils/notify-new-version.js";
+export { packageKey, pathFromKey } from "./utils/package-key.js";
 export { getPackageManager } from "./utils/package-manager.js";
 export { PUBM_ENGINES, PUBM_VERSION } from "./utils/pubm-metadata.js";
 export type { ReleasePhase } from "./utils/resolve-phases.js";

--- a/packages/core/src/manifest/write-versions.ts
+++ b/packages/core/src/manifest/write-versions.ts
@@ -1,5 +1,6 @@
 import type { ResolvedPackageConfig } from "../config/types.js";
 import type { Ecosystem } from "../ecosystem/ecosystem.js";
+import { packageKey } from "../utils/package-key.js";
 
 export async function writeVersionsForEcosystem(
   ecosystems: { eco: Ecosystem; pkg: ResolvedPackageConfig }[],
@@ -8,9 +9,9 @@ export async function writeVersionsForEcosystem(
 ): Promise<string[]> {
   const modifiedFiles: string[] = [];
 
-  // Phase 1: Write versions to manifests (path-keyed by pkg.path)
+  // Phase 1: Write versions to manifests (keyed by packageKey)
   for (const { eco, pkg } of ecosystems) {
-    const version = versions.get(pkg.path);
+    const version = versions.get(packageKey(pkg));
     if (version) {
       await eco.writeVersion(version);
       // Invalidate ManifestReader cache
@@ -25,7 +26,7 @@ export async function writeVersionsForEcosystem(
     const nameKeyedVersions = new Map<string, string>();
     for (const { eco, pkg } of ecosystems) {
       const name = await eco.packageName();
-      const version = versions.get(pkg.path);
+      const version = versions.get(packageKey(pkg));
       if (version) nameKeyedVersions.set(name, version);
     }
     await Promise.all(

--- a/packages/core/src/monorepo/discover.ts
+++ b/packages/core/src/monorepo/discover.ts
@@ -127,8 +127,7 @@ async function resolvePackages(
 ): Promise<ResolvedPackage[]> {
   const absPath = path.resolve(cwd, target.path);
 
-  let descriptors: import("../ecosystem/catalog.js").EcosystemDescriptor[] =
-    [];
+  let descriptors: import("../ecosystem/catalog.js").EcosystemDescriptor[] = [];
 
   if (target.ecosystem) {
     const desc = ecosystemCatalog.get(target.ecosystem);

--- a/packages/core/src/monorepo/discover.ts
+++ b/packages/core/src/monorepo/discover.ts
@@ -4,6 +4,7 @@ import micromatch from "micromatch";
 import type { PackageConfig } from "../config/types.js";
 import { type EcosystemKey, ecosystemCatalog } from "../ecosystem/catalog.js";
 import { inferRegistries } from "../ecosystem/infer.js";
+import { registryCatalog } from "../registry/catalog.js";
 import type { RegistryType } from "../types/options.js";
 import { detectWorkspace } from "./workspace.js";
 
@@ -120,64 +121,78 @@ async function discoverFromWorkspace(
   return targets;
 }
 
-async function resolvePackage(
+async function resolvePackages(
   cwd: string,
   target: DiscoverTarget,
-): Promise<ResolvedPackage | null> {
+): Promise<ResolvedPackage[]> {
   const absPath = path.resolve(cwd, target.path);
 
-  // Detect or use explicit ecosystem
-  let descriptor:
-    | import("../ecosystem/catalog.js").EcosystemDescriptor
-    | null
-    | undefined;
+  let descriptors: import("../ecosystem/catalog.js").EcosystemDescriptor[] =
+    [];
+
   if (target.ecosystem) {
-    descriptor = ecosystemCatalog.get(target.ecosystem);
+    const desc = ecosystemCatalog.get(target.ecosystem);
+    if (desc) descriptors = [desc];
+  } else if (target.registries && target.registries.length > 0) {
+    const detected = await ecosystemCatalog.detectAll(absPath);
+    const registryEcosystems = new Set(
+      target.registries
+        .map((r) => registryCatalog.get(r)?.ecosystem)
+        .filter((e): e is EcosystemKey => e !== undefined),
+    );
+    descriptors = detected.filter((d) => registryEcosystems.has(d.key));
   } else {
-    descriptor = await ecosystemCatalog.detect(absPath);
+    descriptors = await ecosystemCatalog.detectAll(absPath);
   }
 
-  if (!descriptor) return null;
+  const results: ResolvedPackage[] = [];
 
-  const ecosystemKey = descriptor.key;
-  const ecosystem = new descriptor.ecosystemClass(absPath);
+  for (const descriptor of descriptors) {
+    const ecosystemKey = descriptor.key;
+    const ecosystem = new descriptor.ecosystemClass(absPath);
 
-  // Read manifest for name, version, private, dependencies
-  let manifest: {
-    name: string;
-    version: string;
-    private: boolean;
-    dependencies: string[];
-  };
-  try {
-    manifest = await ecosystem.readManifest();
-  } catch {
-    return null;
+    // Read manifest for name, version, private, dependencies
+    let manifest: {
+      name: string;
+      version: string;
+      private: boolean;
+      dependencies: string[];
+    };
+    try {
+      manifest = await ecosystem.readManifest();
+    } catch {
+      continue;
+    }
+
+    // Filter private packages
+    if (manifest.private) continue;
+
+    // Read registry versions for mismatch detection
+    const registryVersions = await ecosystem.readRegistryVersions();
+    const versionValues = [...registryVersions.values()];
+    const hasVersionMismatch =
+      versionValues.length > 1 &&
+      !versionValues.every((v) => v === versionValues[0]);
+
+    // Determine registries
+    const registries = target.registries
+      ? target.registries.filter(
+          (r) => registryCatalog.get(r)?.ecosystem === ecosystemKey,
+        )
+      : await inferRegistries(absPath, ecosystemKey, cwd);
+
+    results.push({
+      name: manifest.name,
+      version: manifest.version,
+      path: target.path,
+      ecosystem: ecosystemKey,
+      registries,
+      dependencies: manifest.dependencies,
+      ...(hasVersionMismatch ? { registryVersions } : {}),
+    });
   }
 
-  // Filter private packages
-  if (manifest.private) return null;
-
-  // Read registry versions for mismatch detection
-  const registryVersions = await ecosystem.readRegistryVersions();
-  const versionValues = [...registryVersions.values()];
-  const hasVersionMismatch =
-    versionValues.length > 1 &&
-    !versionValues.every((v) => v === versionValues[0]);
-
-  // Determine registries
-  const registries =
-    target.registries ?? (await inferRegistries(absPath, ecosystemKey, cwd));
-
-  return {
-    name: manifest.name,
-    version: manifest.version,
-    path: target.path,
-    ecosystem: ecosystemKey,
-    registries,
-    dependencies: manifest.dependencies,
-    ...(hasVersionMismatch ? { registryVersions } : {}),
-  };
+  return results;
 }
 
 export async function discoverPackages(
@@ -204,10 +219,10 @@ export async function discoverPackages(
     });
 
     const results = await Promise.all(
-      targets.map((target) => resolvePackage(cwd, target)),
+      targets.map((target) => resolvePackages(cwd, target)),
     );
 
-    return results.filter((r): r is ResolvedPackage => r !== null);
+    return results.flat();
   }
 
   // Workspace discovery
@@ -217,15 +232,14 @@ export async function discoverPackages(
   if (targets.length === 0) {
     const workspaces = detectWorkspace(cwd);
     if (workspaces.length === 0) {
-      const result = await resolvePackage(cwd, { path: "." });
-      return result ? [result] : [];
+      return await resolvePackages(cwd, { path: "." });
     }
   }
 
   // Resolve each target in parallel
   const results = await Promise.all(
-    targets.map((target) => resolvePackage(cwd, target)),
+    targets.map((target) => resolvePackages(cwd, target)),
   );
 
-  return results.filter((r): r is ResolvedPackage => r !== null);
+  return results.flat();
 }

--- a/packages/core/src/tasks/crates.ts
+++ b/packages/core/src/tasks/crates.ts
@@ -9,6 +9,7 @@ import {
   type CratesPackageRegistry,
   cratesPackageRegistry,
 } from "../registry/crates.js";
+import { pathFromKey } from "../utils/package-key.js";
 import { ui } from "../utils/ui.js";
 
 class CratesError extends AbstractError {
@@ -26,12 +27,12 @@ async function getCrateName(packagePath: string): Promise<string> {
 }
 
 export function createCratesAvailableCheckTask(
-  packagePath: string,
+  key: string,
 ): ListrTask<PubmContext> {
   return {
-    title: t("task.crates.checkAvailability", { path: packagePath }),
+    title: t("task.crates.checkAvailability", { path: pathFromKey(key) }),
     task: async (): Promise<void> => {
-      const registry = await cratesPackageRegistry(packagePath);
+      const registry = await cratesPackageRegistry(pathFromKey(key));
       const connector = new CratesConnector();
 
       if (!(await connector.isInstalled())) {
@@ -45,16 +46,15 @@ export function createCratesAvailableCheckTask(
   };
 }
 
-export function createCratesPublishTask(
-  packagePath: string,
-): ListrTask<PubmContext> {
+export function createCratesPublishTask(key: string): ListrTask<PubmContext> {
+  const packagePath = pathFromKey(key);
   return {
     title: t("task.crates.publishing", { path: packagePath }),
     task: async (ctx, task): Promise<void> => {
       const packageName = await getCrateName(packagePath);
       const registry = await cratesPackageRegistry(packagePath);
 
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       // Pre-check: skip if version already published
       if (await registry.isVersionPublished(version)) {

--- a/packages/core/src/tasks/dry-run-publish.ts
+++ b/packages/core/src/tasks/dry-run-publish.ts
@@ -7,6 +7,7 @@ import { registryCatalog } from "../registry/catalog.js";
 import { cratesPackageRegistry } from "../registry/crates.js";
 import { jsrPackageRegistry } from "../registry/jsr.js";
 import { npmPackageRegistry } from "../registry/npm.js";
+import { pathFromKey } from "../utils/package-key.js";
 import { SecureStore } from "../utils/secure-store.js";
 
 const AUTH_ERROR_PATTERNS = [
@@ -66,14 +67,14 @@ async function withTokenRetry(
 }
 
 export function createNpmDryRunPublishTask(
-  packagePath: string,
+  key: string,
 ): ListrTask<PubmContext> {
   return {
-    title: packagePath,
+    title: key,
     task: async (ctx, task): Promise<void> => {
-      const npm = await npmPackageRegistry(packagePath);
+      const npm = await npmPackageRegistry(pathFromKey(key));
       task.title = npm.packageName;
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       if (await npm.isVersionPublished(version)) {
         task.title = t("task.dryRun.npm.skipped", { version });
@@ -93,14 +94,14 @@ export function createNpmDryRunPublishTask(
 }
 
 export function createJsrDryRunPublishTask(
-  packagePath: string,
+  key: string,
 ): ListrTask<PubmContext> {
   return {
-    title: packagePath,
+    title: key,
     task: async (ctx, task): Promise<void> => {
-      const jsr = await jsrPackageRegistry(packagePath);
+      const jsr = await jsrPackageRegistry(pathFromKey(key));
       task.title = jsr.packageName;
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       if (await jsr.isVersionPublished(version)) {
         task.title = t("task.dryRun.jsr.skipped", { version });
@@ -159,16 +160,18 @@ async function findUnpublishedSiblingDeps(
 }
 
 export function createCratesDryRunPublishTask(
-  packagePath: string,
-  siblingPaths?: string[],
+  key: string,
+  siblingKeys?: string[],
 ): ListrTask<PubmContext> {
+  const packagePath = pathFromKey(key);
+  const siblingPaths = siblingKeys?.map(pathFromKey);
   return {
     title: t("task.dryRun.crates.title", { path: packagePath }),
     task: async (ctx, task): Promise<void> => {
       // Pre-check: skip if version already published
       const registry = await cratesPackageRegistry(packagePath);
       const packageName = registry.packageName;
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       if (await registry.isVersionPublished(version)) {
         task.title = t("task.dryRun.crates.skipped", {

--- a/packages/core/src/tasks/grouping.ts
+++ b/packages/core/src/tasks/grouping.ts
@@ -4,6 +4,7 @@ import { ecosystemCatalog } from "../ecosystem/catalog.js";
 import { t } from "../i18n/index.js";
 import { registryCatalog } from "../registry/catalog.js";
 import type { RegistryType } from "../types/options.js";
+import { packageKey } from "../utils/package-key.js";
 
 interface RegistrySource {
   packages?: ResolvedPackageConfig[];
@@ -11,7 +12,7 @@ interface RegistrySource {
 
 export interface RegistryGroup {
   registry: RegistryType;
-  packagePaths: string[];
+  packageKeys: string[];
 }
 
 export interface EcosystemGroup {
@@ -78,16 +79,16 @@ export function collectEcosystemRegistryGroups(
         ensureRegistrySet(
           resolveEcosystem(registry, pkg.ecosystem),
           registry,
-        ).add(pkg.path);
+        ).add(packageKey(pkg));
       }
     }
   }
 
   return [...ecosystems.entries()].map(([ecosystem, registries]) => ({
     ecosystem,
-    registries: [...registries.entries()].map(([registry, packagePaths]) => ({
+    registries: [...registries.entries()].map(([registry, packageKeys]) => ({
       registry,
-      packagePaths: [...packagePaths],
+      packageKeys: [...packageKeys],
     })),
   }));
 }

--- a/packages/core/src/tasks/jsr.ts
+++ b/packages/core/src/tasks/jsr.ts
@@ -6,6 +6,7 @@ import { AbstractError } from "../error.js";
 import { t } from "../i18n/index.js";
 import { JsrClient, jsrPackageRegistry } from "../registry/jsr.js";
 import { openUrl } from "../utils/open-url.js";
+import { pathFromKey } from "../utils/package-key.js";
 
 class JsrAvailableError extends AbstractError {
   name = t("error.jsr.unavailable");
@@ -17,16 +18,14 @@ class JsrAvailableError extends AbstractError {
   }
 }
 
-export function createJsrPublishTask(
-  packagePath: string,
-): ListrTask<PubmContext> {
+export function createJsrPublishTask(key: string): ListrTask<PubmContext> {
   return {
-    title: packagePath,
+    title: key,
     task: async (ctx, task): Promise<void> => {
-      const jsr = await jsrPackageRegistry(packagePath);
+      const jsr = await jsrPackageRegistry(pathFromKey(key));
       task.title = jsr.packageName;
 
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       // Pre-check: skip if version already published
       if (await jsr.isVersionPublished(version)) {

--- a/packages/core/src/tasks/npm.ts
+++ b/packages/core/src/tasks/npm.ts
@@ -7,6 +7,7 @@ import { t } from "../i18n/index.js";
 import { registryCatalog } from "../registry/catalog.js";
 import type { NpmPackageRegistry } from "../registry/npm.js";
 import { npmPackageRegistry } from "../registry/npm.js";
+import { pathFromKey } from "../utils/package-key.js";
 import { ui } from "../utils/ui.js";
 
 class NpmAvailableError extends AbstractError {
@@ -19,17 +20,15 @@ class NpmAvailableError extends AbstractError {
   }
 }
 
-export function createNpmPublishTask(
-  packagePath: string,
-): ListrTask<PubmContext> {
+export function createNpmPublishTask(key: string): ListrTask<PubmContext> {
   return {
-    title: packagePath,
+    title: key,
     skip: (ctx) => !!ctx.options.dryRun,
     task: async (ctx, task): Promise<void> => {
-      const npm = await npmPackageRegistry(packagePath);
+      const npm = await npmPackageRegistry(pathFromKey(key));
       task.title = npm.packageName;
 
-      const version = getPackageVersion(ctx, packagePath);
+      const version = getPackageVersion(ctx, key);
 
       // Pre-check: skip if version already published
       if (await npm.isVersionPublished(version)) {

--- a/packages/core/src/tasks/phases/dry-run.ts
+++ b/packages/core/src/tasks/phases/dry-run.ts
@@ -15,7 +15,6 @@ import {
 } from "../runner-utils/manifest-handling.js";
 import { formatRegistryGroupSummary } from "../runner-utils/output-formatting.js";
 import { collectDryRunPublishTasks } from "../runner-utils/publish-tasks.js";
-import { requirePackageEcosystem } from "../runner-utils/rollback-handlers.js";
 import { writeVersions } from "../runner-utils/write-versions.js";
 
 export function createDryRunTasks(
@@ -62,8 +61,7 @@ export function createDryRunTasks(
         // Re-sync lockfile to reflect restored workspace:* protocols
         for (const pkg of ctx.config.packages) {
           const absPath = path.resolve(ctx.cwd ?? process.cwd(), pkg.path);
-          const ecosystem = requirePackageEcosystem(pkg);
-          const descriptor = ecosystemCatalog.get(ecosystem);
+          const descriptor = ecosystemCatalog.get(pkg.ecosystem);
           if (!descriptor) continue;
           const eco = new descriptor.ecosystemClass(absPath);
           await eco.syncLockfile(ctx.config.lockfileSync);

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -11,6 +11,7 @@ import {
   saveGitHubToken,
 } from "../../utils/github-token.js";
 import { openUrl } from "../../utils/open-url.js";
+import { pathFromKey } from "../../utils/package-key.js";
 import { ui } from "../../utils/ui.js";
 import { createGitHubRelease, deleteGitHubRelease } from "../github-release.js";
 import { buildReleaseBody, truncateForUrl } from "../release-notes.js";
@@ -134,9 +135,10 @@ export function createReleaseTask(
 
         if (plan.mode === "independent") {
           // Per-package releases
-          for (const [pkgPath, pkgVersion] of plan.packages) {
+          for (const [key, pkgVersion] of plan.packages) {
+            const pkgPath = pathFromKey(key);
             if (isReleaseExcluded(ctx.config, pkgPath)) continue;
-            const pkgName = getPackageName(ctx, pkgPath);
+            const pkgName = getPackageName(ctx, key);
             const tag = `${pkgName}@${pkgVersion}`;
             task.output = t("task.release.creating", { tag });
 
@@ -209,7 +211,8 @@ export function createReleaseTask(
             .replace(/\.git$/, "");
 
           const body = await buildReleaseBody(ctx, {
-            pkgPath: plan.mode === "single" ? plan.packageKey : undefined,
+            pkgPath:
+              plan.mode === "single" ? pathFromKey(plan.packageKey) : undefined,
             version,
             tag,
             repositoryUrl,
@@ -221,7 +224,7 @@ export function createReleaseTask(
               : (ctx.config.packages[0]?.name ?? "");
           const pkgPath =
             plan.mode === "single"
-              ? plan.packageKey
+              ? pathFromKey(plan.packageKey)
               : ctx.config.packages[0]?.path;
           const { assets: preparedAssets, tempDir } =
             await prepareReleaseAssets(ctx, packageName, version, pkgPath);
@@ -279,9 +282,10 @@ export function createReleaseTask(
 
         if (plan.mode === "independent") {
           let first = true;
-          for (const [pkgPath, pkgVersion] of plan.packages) {
+          for (const [key, pkgVersion] of plan.packages) {
+            const pkgPath = pathFromKey(key);
             if (isReleaseExcluded(ctx.config, pkgPath)) continue;
-            const pkgName = getPackageName(ctx, pkgPath);
+            const pkgName = getPackageName(ctx, key);
             const tag = `${pkgName}@${pkgVersion}`;
 
             const body = await buildReleaseBody(ctx, {
@@ -323,7 +327,8 @@ export function createReleaseTask(
           const tag = `v${version}`;
 
           const body = await buildReleaseBody(ctx, {
-            pkgPath: plan.mode === "single" ? plan.packageKey : undefined,
+            pkgPath:
+              plan.mode === "single" ? pathFromKey(plan.packageKey) : undefined,
             version,
             tag,
             repositoryUrl,

--- a/packages/core/src/tasks/phases/push-release.ts
+++ b/packages/core/src/tasks/phases/push-release.ts
@@ -209,7 +209,7 @@ export function createReleaseTask(
             .replace(/\.git$/, "");
 
           const body = await buildReleaseBody(ctx, {
-            pkgPath: plan.mode === "single" ? plan.packagePath : undefined,
+            pkgPath: plan.mode === "single" ? plan.packageKey : undefined,
             version,
             tag,
             repositoryUrl,
@@ -217,11 +217,11 @@ export function createReleaseTask(
 
           const packageName =
             plan.mode === "single"
-              ? getPackageName(ctx, plan.packagePath)
+              ? getPackageName(ctx, plan.packageKey)
               : (ctx.config.packages[0]?.name ?? "");
           const pkgPath =
             plan.mode === "single"
-              ? plan.packagePath
+              ? plan.packageKey
               : ctx.config.packages[0]?.path;
           const { assets: preparedAssets, tempDir } =
             await prepareReleaseAssets(ctx, packageName, version, pkgPath);
@@ -323,7 +323,7 @@ export function createReleaseTask(
           const tag = `v${version}`;
 
           const body = await buildReleaseBody(ctx, {
-            pkgPath: plan.mode === "single" ? plan.packagePath : undefined,
+            pkgPath: plan.mode === "single" ? plan.packageKey : undefined,
             version,
             tag,
             repositoryUrl,

--- a/packages/core/src/tasks/phases/version.ts
+++ b/packages/core/src/tasks/phases/version.ts
@@ -16,6 +16,7 @@ import type { PubmContext } from "../../context.js";
 import { AbstractError } from "../../error.js";
 import { Git } from "../../git.js";
 import { t } from "../../i18n/index.js";
+import { pathFromKey } from "../../utils/package-key.js";
 import {
   formatVersionPlan,
   formatVersionSummary,
@@ -159,8 +160,8 @@ export function createVersionTask(
             registerChangelogBackup(ctx, changelogPath);
 
             const allEntries = deduplicateEntries(
-              [...plan.packages.keys()].flatMap((pkgPath) =>
-                buildChangelogEntries(changesets, pkgPath),
+              [...plan.packages.keys()].flatMap((key) =>
+                buildChangelogEntries(changesets, key),
               ),
             );
             if (allEntries.length > 0) {
@@ -206,9 +207,7 @@ export function createVersionTask(
 
         task.output = t("task.version.creatingCommit", { tag: tagName });
         const fixedCommitMsg = `Version Packages\n\n${[...plan.packages]
-          .map(
-            ([pkgPath]) => `- ${getPackageName(ctx, pkgPath)}: ${plan.version}`,
-          )
+          .map(([key]) => `- ${getPackageName(ctx, key)}: ${plan.version}`)
           .join("\n")}`;
         const commit = await git.commit(fixedCommitMsg);
         registerCommitRollback(ctx);
@@ -240,9 +239,9 @@ export function createVersionTask(
             registerChangesetBackups(ctx, changesets);
 
             // Back up changelog files (per-package for independent mode)
-            for (const [pkgPath] of plan.packages) {
+            for (const [key] of plan.packages) {
               const pkgConfig = ctx.config.packages.find(
-                (p) => p.path === pkgPath,
+                (p) => p.path === pathFromKey(key),
               );
               const changelogDir = pkgConfig
                 ? path.resolve(ctx.cwd, pkgConfig.path)
@@ -251,11 +250,11 @@ export function createVersionTask(
               registerChangelogBackup(ctx, changelogPath);
             }
 
-            for (const [pkgPath, pkgVersion] of plan.packages) {
-              const entries = buildChangelogEntries(changesets, pkgPath);
+            for (const [key, pkgVersion] of plan.packages) {
+              const entries = buildChangelogEntries(changesets, key);
               if (entries.length > 0) {
                 const pkgConfig = ctx.config.packages.find(
-                  (p) => p.path === pkgPath,
+                  (p) => p.path === pathFromKey(key),
                 );
                 const changelogDir = pkgConfig
                   ? path.resolve(ctx.cwd, pkgConfig.path)
@@ -276,9 +275,9 @@ export function createVersionTask(
         await git.stage(".");
 
         // Tag existence checks for all packages
-        for (const [pkgPath, pkgVersion] of plan.packages) {
-          if (isReleaseExcluded(ctx.config, pkgPath)) continue;
-          const pkgName = getPackageName(ctx, pkgPath);
+        for (const [key, pkgVersion] of plan.packages) {
+          if (isReleaseExcluded(ctx.config, pathFromKey(key))) continue;
+          const pkgName = getPackageName(ctx, key);
           const tagName = `${pkgName}@${pkgVersion}`;
           if (await git.checkTagExist(tagName)) {
             if (ctx.runtime.promptEnabled) {
@@ -307,7 +306,7 @@ export function createVersionTask(
 
         // Commit with "Version Packages" message
         const commitMsg = `Version Packages\n\n${[...plan.packages]
-          .map(([pkgPath, ver]) => `- ${getPackageName(ctx, pkgPath)}: ${ver}`)
+          .map(([key, ver]) => `- ${getPackageName(ctx, key)}: ${ver}`)
           .join("\n")}`;
         task.output = t("task.version.creatingCommitGeneric");
         const commit = await git.commit(commitMsg);
@@ -315,9 +314,9 @@ export function createVersionTask(
 
         // Create per-package tags
         task.output = t("task.version.creatingTags");
-        for (const [pkgPath, pkgVersion] of plan.packages) {
-          if (isReleaseExcluded(ctx.config, pkgPath)) continue;
-          const pkgName = getPackageName(ctx, pkgPath);
+        for (const [key, pkgVersion] of plan.packages) {
+          if (isReleaseExcluded(ctx.config, pathFromKey(key))) continue;
+          const pkgName = getPackageName(ctx, key);
           const tag = `${pkgName}@${pkgVersion}`;
           await git.createTag(tag, commit);
           registerTagRollback(ctx, tag);

--- a/packages/core/src/tasks/prompts/display.ts
+++ b/packages/core/src/tasks/prompts/display.ts
@@ -78,7 +78,7 @@ export function buildDependencyBumpNote(
 
 export function renderPackageVersionSummary(
   packageInfos: ResolvedPackageConfig[],
-  currentVersions: Map<string, string>,
+  _currentVersions: Map<string, string>,
   selectedVersions: Map<string, string>,
   options: {
     activePackage?: string;
@@ -88,7 +88,7 @@ export function renderPackageVersionSummary(
   const lines = [t("output.packages")];
 
   for (const pkg of packageInfos) {
-    const currentVersion = currentVersions.get(pkg.path) ?? pkg.version;
+    const currentVersion = pkg.version;
     const selectedVersion = selectedVersions.get(packageKey(pkg));
     const prefix = options.activePackage === pkg.path ? "> " : "  ";
 

--- a/packages/core/src/tasks/prompts/display.ts
+++ b/packages/core/src/tasks/prompts/display.ts
@@ -2,6 +2,7 @@ import { color } from "listr2";
 import semver from "semver";
 import type { ResolvedPackageConfig } from "../../config/types.js";
 import { t } from "../../i18n/index.js";
+import { packageKey } from "../../utils/package-key.js";
 import { ui } from "../../utils/ui.js";
 import type { VersionRecommendation } from "../../version-source/types.js";
 
@@ -88,7 +89,9 @@ export function renderPackageVersionSummary(
 
   for (const pkg of packageInfos) {
     const currentVersion = currentVersions.get(pkg.path) ?? pkg.version;
-    const selectedVersion = selectedVersions.get(pkg.path);
+    // selectedVersions may be keyed by packageKey (path::ecosystem) or plain path
+    const selectedVersion =
+      selectedVersions.get(packageKey(pkg)) ?? selectedVersions.get(pkg.path);
     const prefix = options.activePackage === pkg.path ? "> " : "  ";
 
     lines.push(

--- a/packages/core/src/tasks/prompts/display.ts
+++ b/packages/core/src/tasks/prompts/display.ts
@@ -89,9 +89,7 @@ export function renderPackageVersionSummary(
 
   for (const pkg of packageInfos) {
     const currentVersion = currentVersions.get(pkg.path) ?? pkg.version;
-    // selectedVersions may be keyed by packageKey (path::ecosystem) or plain path
-    const selectedVersion =
-      selectedVersions.get(packageKey(pkg)) ?? selectedVersions.get(pkg.path);
+    const selectedVersion = selectedVersions.get(packageKey(pkg));
     const prefix = options.activePackage === pkg.path ? "> " : "  ";
 
     lines.push(

--- a/packages/core/src/tasks/prompts/fixed-mode.ts
+++ b/packages/core/src/tasks/prompts/fixed-mode.ts
@@ -75,14 +75,9 @@ export async function handleFixedMode(
     packages,
   };
 
-  // Display uses path-keyed map for renderPackageVersionSummary
-  const displayVersions = new Map<string, string>();
-  for (const pkgPath of currentVersions.keys()) {
-    displayVersions.set(pkgPath, nextVersion);
-  }
   task.output = renderPackageVersionSummary(
     packageInfos,
     currentVersions,
-    displayVersions,
+    packages,
   );
 }

--- a/packages/core/src/tasks/prompts/fixed-mode.ts
+++ b/packages/core/src/tasks/prompts/fixed-mode.ts
@@ -6,6 +6,7 @@ import type { VersionBump } from "../../changeset/version.js";
 import type { ResolvedPackageConfig } from "../../config/types.js";
 import type { PubmContext } from "../../context.js";
 import { t } from "../../i18n/index.js";
+import { packageKey } from "../../utils/package-key.js";
 import { renderPackageVersionSummary } from "./display.js";
 import { versionChoices } from "./version-choices.js";
 
@@ -65,8 +66,8 @@ export async function handleFixedMode(
   }
 
   const packages = new Map<string, string>();
-  for (const pkgPath of currentVersions.keys()) {
-    packages.set(pkgPath, nextVersion);
+  for (const pkg of packageInfos) {
+    packages.set(packageKey(pkg), nextVersion);
   }
   ctx.runtime.versionPlan = {
     mode: "fixed",

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -75,13 +75,13 @@ export async function handleMultiPackage(
   if (isCI && recommendations.length > 0) {
     const packages = new Map<string, string>();
     for (const rec of recommendations) {
-      const current = currentVersions.get(rec.packagePath);
-      if (!current) continue;
-      const newVer = semver.inc(current, rec.bumpType);
-      if (newVer) {
-        const keys = pathToKeys.get(rec.packagePath) ?? [rec.packagePath];
-        for (const key of keys) {
-          packages.set(key, newVer);
+      const matchingPkgs = packageInfos.filter(
+        (p) => p.path === rec.packagePath,
+      );
+      for (const pkg of matchingPkgs) {
+        const newVer = semver.inc(pkg.version, rec.bumpType);
+        if (newVer) {
+          packages.set(packageKey(pkg), newVer);
         }
       }
     }
@@ -130,13 +130,13 @@ export async function handleMultiPackage(
   if (action === "accept") {
     selectedVersions = new Map();
     for (const rec of recommendations) {
-      const current = currentVersions.get(rec.packagePath);
-      if (!current) continue;
-      const newVer = semver.inc(current, rec.bumpType);
-      if (newVer) {
-        const keys = pathToKeys.get(rec.packagePath) ?? [rec.packagePath];
-        for (const key of keys) {
-          selectedVersions.set(key, newVer);
+      const matchingPkgs = packageInfos.filter(
+        (p) => p.path === rec.packagePath,
+      );
+      for (const pkg of matchingPkgs) {
+        const newVer = semver.inc(pkg.version, rec.bumpType);
+        if (newVer) {
+          selectedVersions.set(packageKey(pkg), newVer);
         }
       }
     }
@@ -337,12 +337,12 @@ export async function handleIndependentMode(
 
     if (cascadeChoice === "patch") {
       for (const pkgPath of uniqueDependents) {
-        const currentVersion =
-          currentVersions.get(pkgPath) ??
-          (packageVersionByPath.get(pkgPath) as string);
-        const patchVersion = new SemVer(currentVersion).inc("patch").toString();
         const pkgs = packageInfos.filter((p) => p.path === pkgPath);
         for (const pkg of pkgs) {
+          const currentVersion = pkg.version;
+          const patchVersion = new SemVer(currentVersion)
+            .inc("patch")
+            .toString();
           versions.set(packageKey(pkg), patchVersion);
         }
       }

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -171,8 +171,7 @@ export async function handleMultiPackage(
         plan.packages = new Map(
           [...plan.packages].filter(([k]) => publishKeys.has(k)),
         );
-        const publishPaths = new Set([...publishKeys].map(pathFromKey));
-        filterConfigPackages(ctx, publishPaths);
+        filterConfigPackages(ctx, publishKeys);
       }
     }
     const plan = ctx.runtime.versionPlan;

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -14,7 +14,7 @@ import type {
 } from "../../context.js";
 import { t } from "../../i18n/index.js";
 import { filterConfigPackages } from "../../utils/filter-config.js";
-import { packageKey, pathFromKey } from "../../utils/package-key.js";
+import { packageKey } from "../../utils/package-key.js";
 import { ui } from "../../utils/ui.js";
 import {
   buildDependencyBumpNote,
@@ -170,10 +170,12 @@ export async function handleMultiPackage(
       // Filter out packages where the selected version equals the current version.
       const plan = ctx.runtime.versionPlan;
       if (plan && plan.mode === "independent") {
+        const currentVersionsByKey = new Map(
+          packageInfos.map((p) => [packageKey(p), p.version]),
+        );
         const publishKeys = new Set<string>();
         for (const [key, selectedVersion] of plan.packages) {
-          const pkgPath = pathFromKey(key);
-          if (selectedVersion !== (currentVersions.get(pkgPath) ?? "")) {
+          if (selectedVersion !== (currentVersionsByKey.get(key) ?? "")) {
             publishKeys.add(key);
           }
         }

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -63,7 +63,12 @@ export async function handleMultiPackage(
 ): Promise<void> {
   const graph = buildGraphFromPackages(packageInfos);
   const currentVersions = new Map(packageInfos.map((p) => [p.path, p.version]));
-  const pathToKey = new Map(packageInfos.map((p) => [p.path, packageKey(p)]));
+  const pathToKeys = new Map<string, string[]>();
+  for (const p of packageInfos) {
+    const existing = pathToKeys.get(p.path) ?? [];
+    existing.push(packageKey(p));
+    pathToKeys.set(p.path, existing);
+  }
   const recommendations = await analyzeAllSources(ctx);
 
   // CI mode: auto-accept
@@ -74,8 +79,10 @@ export async function handleMultiPackage(
       if (!current) continue;
       const newVer = semver.inc(current, rec.bumpType);
       if (newVer) {
-        const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
-        packages.set(key, newVer);
+        const keys = pathToKeys.get(rec.packagePath) ?? [rec.packagePath];
+        for (const key of keys) {
+          packages.set(key, newVer);
+        }
       }
     }
     ctx.runtime.versionPlan = buildVersionPlan(
@@ -83,8 +90,8 @@ export async function handleMultiPackage(
       packages,
     );
     ctx.runtime.changesetConsumed = recommendations.some((r) => {
-      const key = pathToKey.get(r.packagePath) ?? r.packagePath;
-      return r.source === "changeset" && packages.has(key);
+      const keys = pathToKeys.get(r.packagePath) ?? [r.packagePath];
+      return r.source === "changeset" && keys.some((k) => packages.has(k));
     });
     return;
   }
@@ -127,8 +134,10 @@ export async function handleMultiPackage(
       if (!current) continue;
       const newVer = semver.inc(current, rec.bumpType);
       if (newVer) {
-        const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
-        selectedVersions.set(key, newVer);
+        const keys = pathToKeys.get(rec.packagePath) ?? [rec.packagePath];
+        for (const key of keys) {
+          selectedVersions.set(key, newVer);
+        }
       }
     }
   } else {
@@ -178,8 +187,8 @@ export async function handleMultiPackage(
     ctx.runtime.changesetConsumed = recommendations.some((r) => {
       if (r.source !== "changeset" || !plan || !("packages" in plan))
         return false;
-      const key = pathToKey.get(r.packagePath) ?? r.packagePath;
-      return plan.packages.has(key);
+      const keys = pathToKeys.get(r.packagePath) ?? [r.packagePath];
+      return keys.some((k) => plan.packages.has(k));
     });
     return;
   }
@@ -191,8 +200,8 @@ export async function handleMultiPackage(
     selectedVersions,
   );
   ctx.runtime.changesetConsumed = recommendations.some((r) => {
-    const key = pathToKey.get(r.packagePath) ?? r.packagePath;
-    return r.source === "changeset" && selectedVersions.has(key);
+    const keys = pathToKeys.get(r.packagePath) ?? [r.packagePath];
+    return r.source === "changeset" && keys.some((k) => selectedVersions.has(k));
   });
 }
 
@@ -330,8 +339,8 @@ export async function handleIndependentMode(
           currentVersions.get(pkgPath) ??
           (packageVersionByPath.get(pkgPath) as string);
         const patchVersion = new SemVer(currentVersion).inc("patch").toString();
-        const pkg = packageInfos.find((p) => p.path === pkgPath);
-        if (pkg) {
+        const pkgs = packageInfos.filter((p) => p.path === pkgPath);
+        for (const pkg of pkgs) {
           versions.set(packageKey(pkg), patchVersion);
         }
       }

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -201,7 +201,9 @@ export async function handleMultiPackage(
   );
   ctx.runtime.changesetConsumed = recommendations.some((r) => {
     const keys = pathToKeys.get(r.packagePath) ?? [r.packagePath];
-    return r.source === "changeset" && keys.some((k) => selectedVersions.has(k));
+    return (
+      r.source === "changeset" && keys.some((k) => selectedVersions.has(k))
+    );
   });
 }
 

--- a/packages/core/src/tasks/prompts/independent-mode.ts
+++ b/packages/core/src/tasks/prompts/independent-mode.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../context.js";
 import { t } from "../../i18n/index.js";
 import { filterConfigPackages } from "../../utils/filter-config.js";
+import { packageKey, pathFromKey } from "../../utils/package-key.js";
 import { ui } from "../../utils/ui.js";
 import {
   buildDependencyBumpNote,
@@ -62,6 +63,7 @@ export async function handleMultiPackage(
 ): Promise<void> {
   const graph = buildGraphFromPackages(packageInfos);
   const currentVersions = new Map(packageInfos.map((p) => [p.path, p.version]));
+  const pathToKey = new Map(packageInfos.map((p) => [p.path, packageKey(p)]));
   const recommendations = await analyzeAllSources(ctx);
 
   // CI mode: auto-accept
@@ -71,15 +73,19 @@ export async function handleMultiPackage(
       const current = currentVersions.get(rec.packagePath);
       if (!current) continue;
       const newVer = semver.inc(current, rec.bumpType);
-      if (newVer) packages.set(rec.packagePath, newVer);
+      if (newVer) {
+        const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
+        packages.set(key, newVer);
+      }
     }
     ctx.runtime.versionPlan = buildVersionPlan(
       ctx.config.versioning ?? "independent",
       packages,
     );
-    ctx.runtime.changesetConsumed = recommendations.some(
-      (r) => r.source === "changeset" && packages.has(r.packagePath),
-    );
+    ctx.runtime.changesetConsumed = recommendations.some((r) => {
+      const key = pathToKey.get(r.packagePath) ?? r.packagePath;
+      return r.source === "changeset" && packages.has(key);
+    });
     return;
   }
 
@@ -120,7 +126,10 @@ export async function handleMultiPackage(
       const current = currentVersions.get(rec.packagePath);
       if (!current) continue;
       const newVer = semver.inc(current, rec.bumpType);
-      if (newVer) selectedVersions.set(rec.packagePath, newVer);
+      if (newVer) {
+        const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
+        selectedVersions.set(key, newVer);
+      }
     }
   } else {
     // Edit mode: delegate to existing manual flows
@@ -152,26 +161,27 @@ export async function handleMultiPackage(
       // Filter out packages where the selected version equals the current version.
       const plan = ctx.runtime.versionPlan;
       if (plan && plan.mode === "independent") {
-        const publishPaths = new Set<string>();
-        for (const [pkgPath, selectedVersion] of plan.packages) {
+        const publishKeys = new Set<string>();
+        for (const [key, selectedVersion] of plan.packages) {
+          const pkgPath = pathFromKey(key);
           if (selectedVersion !== (currentVersions.get(pkgPath) ?? "")) {
-            publishPaths.add(pkgPath);
+            publishKeys.add(key);
           }
         }
         plan.packages = new Map(
-          [...plan.packages].filter(([p]) => publishPaths.has(p)),
+          [...plan.packages].filter(([k]) => publishKeys.has(k)),
         );
+        const publishPaths = new Set([...publishKeys].map(pathFromKey));
         filterConfigPackages(ctx, publishPaths);
       }
     }
     const plan = ctx.runtime.versionPlan;
-    ctx.runtime.changesetConsumed = recommendations.some(
-      (r) =>
-        r.source === "changeset" &&
-        plan !== undefined &&
-        "packages" in plan &&
-        plan.packages.has(r.packagePath),
-    );
+    ctx.runtime.changesetConsumed = recommendations.some((r) => {
+      if (r.source !== "changeset" || !plan || !("packages" in plan))
+        return false;
+      const key = pathToKey.get(r.packagePath) ?? r.packagePath;
+      return plan.packages.has(key);
+    });
     return;
   }
 
@@ -181,9 +191,10 @@ export async function handleMultiPackage(
     ctx.config.versioning ?? "independent",
     selectedVersions,
   );
-  ctx.runtime.changesetConsumed = recommendations.some(
-    (r) => r.source === "changeset" && selectedVersions.has(r.packagePath),
-  );
+  ctx.runtime.changesetConsumed = recommendations.some((r) => {
+    const key = pathToKey.get(r.packagePath) ?? r.packagePath;
+    return r.source === "changeset" && selectedVersions.has(key);
+  });
 }
 
 /**
@@ -260,7 +271,7 @@ export async function handleIndependentMode(
       bump?.bumpType,
       lastBumpType,
     );
-    versions.set(pkg.path, result.version);
+    versions.set(packageKey(pkg), result.version);
     lastBumpType = result.bumpType;
 
     if (result.version !== currentVersion) {
@@ -320,7 +331,10 @@ export async function handleIndependentMode(
           currentVersions.get(pkgPath) ??
           (packageVersionByPath.get(pkgPath) as string);
         const patchVersion = new SemVer(currentVersion).inc("patch").toString();
-        versions.set(pkgPath, patchVersion);
+        const pkg = packageInfos.find((p) => p.path === pkgPath);
+        if (pkg) {
+          versions.set(packageKey(pkg), patchVersion);
+        }
       }
     }
   }

--- a/packages/core/src/tasks/prompts/single-package.ts
+++ b/packages/core/src/tasks/prompts/single-package.ts
@@ -28,7 +28,7 @@ export async function handleSinglePackage(
         ctx.runtime.versionPlan = {
           mode: "single",
           version: newVer,
-          packagePath: pkg.path,
+          packageKey: pkg.path,
         };
         ctx.runtime.changesetConsumed = rec.source === "changeset";
         return;
@@ -61,7 +61,7 @@ export async function handleSinglePackage(
         ctx.runtime.versionPlan = {
           mode: "single",
           version: newVer,
-          packagePath: pkg.path,
+          packageKey: pkg.path,
         };
         ctx.runtime.changesetConsumed = rec.source === "changeset";
         return;
@@ -88,6 +88,6 @@ export async function handleSinglePackage(
   ctx.runtime.versionPlan = {
     mode: "single",
     version: nextVersion,
-    packagePath: pkg.path,
+    packageKey: pkg.path,
   };
 }

--- a/packages/core/src/tasks/prompts/single-package.ts
+++ b/packages/core/src/tasks/prompts/single-package.ts
@@ -4,6 +4,7 @@ import semver from "semver";
 import { isCI } from "std-env";
 import type { PubmContext } from "../../context.js";
 import { t } from "../../i18n/index.js";
+import { packageKey as makePackageKey } from "../../utils/package-key.js";
 import { displayRecommendationSummary, pluralize } from "./display.js";
 import { analyzeAllSources, versionChoices } from "./version-choices.js";
 
@@ -28,7 +29,7 @@ export async function handleSinglePackage(
         ctx.runtime.versionPlan = {
           mode: "single",
           version: newVer,
-          packageKey: pkg.path,
+          packageKey: makePackageKey(pkg),
         };
         ctx.runtime.changesetConsumed = rec.source === "changeset";
         return;
@@ -61,7 +62,7 @@ export async function handleSinglePackage(
         ctx.runtime.versionPlan = {
           mode: "single",
           version: newVer,
-          packageKey: pkg.path,
+          packageKey: makePackageKey(pkg),
         };
         ctx.runtime.changesetConsumed = rec.source === "changeset";
         return;
@@ -88,6 +89,6 @@ export async function handleSinglePackage(
   ctx.runtime.versionPlan = {
     mode: "single",
     version: nextVersion,
-    packageKey: pkg.path,
+    packageKey: makePackageKey(pkg),
   };
 }

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -122,7 +122,7 @@ export const requiredConditionsCheckTask = (
 
               const byEcosystem = new Map<string, ResolvedPackageConfig[]>();
               for (const pkg of ctx.config.packages) {
-                const key = pkg.ecosystem ?? "js";
+                const key = pkg.ecosystem;
                 if (!byEcosystem.has(key)) byEcosystem.set(key, []);
                 byEcosystem.get(key)!.push(pkg);
               }

--- a/packages/core/src/tasks/required-conditions-check.ts
+++ b/packages/core/src/tasks/required-conditions-check.ts
@@ -13,6 +13,7 @@ import { registryCatalog } from "../registry/catalog.js";
 import { getConnector } from "../registry/index.js";
 import { validateEngineVersion } from "../utils/engine-version.js";
 import { createCiListrOptions, createListr } from "../utils/listr.js";
+import { pathFromKey } from "../utils/package-key.js";
 import {
   collectEcosystemRegistryGroups,
   ecosystemLabel,
@@ -34,18 +35,20 @@ export const requiredConditionsCheckTask = (
 ): Listr<PubmContext> => {
   const createAvailabilityTask = (
     registryKey: string,
-    packagePaths: string[],
+    packageKeys: string[],
   ): ListrTask<PubmContext> => {
     const descriptor = registryCatalog.get(registryKey);
     if (!descriptor) return { title: registryKey, task: async () => {} };
 
-    if (packagePaths.length <= 1) {
+    if (packageKeys.length <= 1) {
       return {
         title: t("task.conditions.checkAvailability", {
           label: descriptor.label,
         }),
         task: async (ctx, task): Promise<void> => {
-          const registry = await descriptor.factory(packagePaths[0]);
+          const registry = await descriptor.factory(
+            pathFromKey(packageKeys[0] ?? ""),
+          );
           await registry.checkAvailability(task, ctx);
         },
       };
@@ -57,10 +60,10 @@ export const requiredConditionsCheckTask = (
       }),
       task: (_ctx, parentTask): Listr<PubmContext> =>
         parentTask.newListr(
-          packagePaths.map((packagePath) => ({
-            title: packagePath,
+          packageKeys.map((key) => ({
+            title: pathFromKey(key),
             task: async (ctx, task): Promise<void> => {
-              const registry = await descriptor.factory(packagePath);
+              const registry = await descriptor.factory(pathFromKey(key));
               await registry.checkAvailability(task, ctx);
             },
           })),
@@ -235,8 +238,8 @@ export const requiredConditionsCheckTask = (
                   title: ecosystemLabel(group.ecosystem),
                   task: (_ctx, ecosystemTask): Listr<PubmContext> =>
                     ecosystemTask.newListr(
-                      group.registries.map(({ registry, packagePaths }) =>
-                        createAvailabilityTask(registry, packagePaths),
+                      group.registries.map(({ registry, packageKeys }) =>
+                        createAvailabilityTask(registry, packageKeys),
                       ),
                       { concurrent: true },
                     ),

--- a/packages/core/src/tasks/runner-utils/manifest-handling.ts
+++ b/packages/core/src/tasks/runner-utils/manifest-handling.ts
@@ -7,7 +7,7 @@ import type { PreparedAsset } from "../../assets/types.js";
 import type { PubmContext } from "../../context.js";
 import { ecosystemCatalog } from "../../ecosystem/catalog.js";
 import { collectWorkspaceVersions } from "../../monorepo/resolve-workspace.js";
-import { requirePackageEcosystem } from "./rollback-handlers.js";
+import { packageKey } from "../../utils/package-key.js";
 import { writeVersions } from "./write-versions.js";
 
 export async function prepareReleaseAssets(
@@ -74,8 +74,7 @@ export async function resolveWorkspaceProtocols(
 
   for (const pkg of ctx.config.packages) {
     const absPath = path.resolve(ctx.cwd, pkg.path);
-    const ecosystem = requirePackageEcosystem(pkg);
-    const descriptor = ecosystemCatalog.get(ecosystem);
+    const descriptor = ecosystemCatalog.get(pkg.ecosystem);
     if (!descriptor) continue;
 
     const eco = new descriptor.ecosystemClass(absPath);
@@ -96,14 +95,14 @@ export async function applyVersionsForDryRun(ctx: PubmContext): Promise<void> {
 
   // Backup original versions from config (safe: writeVersions not yet called in dry-run)
   ctx.runtime.dryRunVersionBackup = new Map(
-    ctx.config.packages.map((pkg) => [pkg.path, pkg.version ?? "0.0.0"]),
+    ctx.config.packages.map((pkg) => [packageKey(pkg), pkg.version ?? "0.0.0"]),
   );
 
   // Build new versions map from versionPlan
   let newVersions: Map<string, string>;
   if (plan.mode === "single") {
     newVersions = new Map(
-      ctx.config.packages.map((pkg) => [pkg.path, plan.version]),
+      ctx.config.packages.map((pkg) => [packageKey(pkg), plan.version]),
     );
   } else {
     // fixed and independent both use plan.packages

--- a/packages/core/src/tasks/runner-utils/output-formatting.ts
+++ b/packages/core/src/tasks/runner-utils/output-formatting.ts
@@ -18,9 +18,9 @@ export function formatRegistryGroupSummary(
   ctx: PubmContext,
 ): string {
   const lines = collectEcosystemRegistryGroups(ctx.config).flatMap((group) =>
-    group.registries.map(({ registry, packagePaths }) => {
+    group.registries.map(({ registry, packageKeys }) => {
       const packageSummary =
-        packagePaths.length > 1 ? ` (${packagePaths.length} packages)` : "";
+        packageKeys.length > 1 ? ` (${packageKeys.length} packages)` : "";
       return `- ${ecosystemLabel(group.ecosystem)} > ${registryLabel(registry)}${packageSummary}`;
     }),
   );

--- a/packages/core/src/tasks/runner-utils/publish-tasks.ts
+++ b/packages/core/src/tasks/runner-utils/publish-tasks.ts
@@ -11,15 +11,15 @@ export type NewListrParentTask<Context extends object> = ListrTaskWrapper<
 
 export function createPublishTaskForPath(
   registryKey: string,
-  packagePath: string,
+  packageKey: string,
 ): ListrTask<PubmContext> {
   const descriptor = registryCatalog.get(registryKey);
   if (!descriptor?.taskFactory?.createPublishTask) {
     throw new Error(
-      `No publish task factory registered for registry "${registryKey}". Cannot publish "${packagePath}".`,
+      `No publish task factory registered for registry "${registryKey}". Cannot publish "${packageKey}".`,
     );
   }
-  return descriptor.taskFactory.createPublishTask(packagePath);
+  return descriptor.taskFactory.createPublishTask(packageKey);
 }
 
 export async function collectPublishTasks(ctx: PubmContext) {
@@ -28,12 +28,12 @@ export async function collectPublishTasks(ctx: PubmContext) {
   const ecosystemTasks = await Promise.all(
     groups.map(async (group) => {
       const registryTasks = await Promise.all(
-        group.registries.map(async ({ registry, packagePaths }) => {
+        group.registries.map(async ({ registry, packageKeys }) => {
           const descriptor = registryCatalog.get(registry);
 
-          const paths = descriptor?.orderPackages
-            ? await descriptor.orderPackages(packagePaths)
-            : packagePaths;
+          const keys = descriptor?.orderPackages
+            ? await descriptor.orderPackages(packageKeys)
+            : packageKeys;
 
           const label = descriptor
             ? `Running ${descriptor.label} publish`
@@ -43,7 +43,7 @@ export async function collectPublishTasks(ctx: PubmContext) {
             title: label,
             task: (_ctx: PubmContext, task: NewListrParentTask<PubmContext>) =>
               task.newListr(
-                paths.map((p) => createPublishTaskForPath(registry, p)),
+                keys.map((k) => createPublishTaskForPath(registry, k)),
                 { concurrent: descriptor?.concurrentPublish ?? true },
               ),
           };
@@ -63,16 +63,16 @@ export async function collectPublishTasks(ctx: PubmContext) {
 
 export function createDryRunTaskForPath(
   registryKey: string,
-  packagePath: string,
-  siblingPaths?: string[],
+  packageKey: string,
+  siblingKeys?: string[],
 ): ListrTask<PubmContext> {
   const descriptor = registryCatalog.get(registryKey);
   if (!descriptor?.taskFactory?.createDryRunTask) {
     throw new Error(
-      `No dry-run task factory registered for registry "${registryKey}". Cannot dry-run publish "${packagePath}".`,
+      `No dry-run task factory registered for registry "${registryKey}". Cannot dry-run publish "${packageKey}".`,
     );
   }
-  return descriptor.taskFactory.createDryRunTask(packagePath, siblingPaths);
+  return descriptor.taskFactory.createDryRunTask(packageKey, siblingKeys);
 }
 
 export async function collectDryRunPublishTasks(ctx: PubmContext) {
@@ -81,17 +81,17 @@ export async function collectDryRunPublishTasks(ctx: PubmContext) {
   return await Promise.all(
     groups.map(async (group) => {
       const registryTasks = await Promise.all(
-        group.registries.map(async ({ registry, packagePaths }) => {
+        group.registries.map(async ({ registry, packageKeys }) => {
           const descriptor = registryCatalog.get(registry);
 
-          const paths = descriptor?.orderPackages
-            ? await descriptor.orderPackages(packagePaths)
-            : packagePaths;
+          const keys = descriptor?.orderPackages
+            ? await descriptor.orderPackages(packageKeys)
+            : packageKeys;
 
-          // For non-concurrent registries with multiple packages, pass sibling paths
-          let siblingPaths: string[] | undefined;
-          if (!descriptor?.concurrentPublish && packagePaths.length > 1) {
-            siblingPaths = packagePaths;
+          // For non-concurrent registries with multiple packages, pass sibling keys
+          let siblingKeys: string[] | undefined;
+          if (!descriptor?.concurrentPublish && packageKeys.length > 1) {
+            siblingKeys = packageKeys;
           }
 
           const concurrent = descriptor?.concurrentPublish ?? true;
@@ -103,8 +103,8 @@ export async function collectDryRunPublishTasks(ctx: PubmContext) {
             title: label,
             task: (_ctx: PubmContext, task: NewListrParentTask<PubmContext>) =>
               task.newListr(
-                paths.map((p) =>
-                  createDryRunTaskForPath(registry, p, siblingPaths),
+                keys.map((k) =>
+                  createDryRunTaskForPath(registry, k, siblingKeys),
                 ),
                 { concurrent },
               ),

--- a/packages/core/src/tasks/runner-utils/rollback-handlers.ts
+++ b/packages/core/src/tasks/runner-utils/rollback-handlers.ts
@@ -3,23 +3,10 @@ import path from "node:path";
 import micromatch from "micromatch";
 import type { Changeset } from "../../changeset/parser.js";
 import type { PubmContext } from "../../context.js";
-import {
-  type EcosystemKey,
-  ecosystemCatalog,
-} from "../../ecosystem/catalog.js";
+import { ecosystemCatalog } from "../../ecosystem/catalog.js";
 import { Git } from "../../git.js";
 import { t } from "../../i18n/index.js";
-
-export function requirePackageEcosystem(pkg: {
-  path: string;
-  ecosystem?: EcosystemKey;
-}): EcosystemKey {
-  if (!pkg.ecosystem) {
-    throw new Error(`Package ${pkg.path} is missing an ecosystem.`);
-  }
-
-  return pkg.ecosystem;
-}
+import { packageKey, pathFromKey } from "../../utils/package-key.js";
 
 export function isReleaseExcluded(
   config: { excludeRelease?: string[] },
@@ -30,10 +17,8 @@ export function isReleaseExcluded(
   return micromatch.isMatch(pkgPath, patterns);
 }
 
-export function getPackageName(ctx: PubmContext, packagePath: string): string {
-  return (
-    ctx.config.packages.find((p) => p.path === packagePath)?.name ?? packagePath
-  );
+export function getPackageName(ctx: PubmContext, key: string): string {
+  return ctx.config.packages.find((p) => packageKey(p) === key)?.name ?? key;
 }
 
 export function requireVersionPlan(ctx: PubmContext) {
@@ -49,8 +34,7 @@ export function requireVersionPlan(ctx: PubmContext) {
 export function registerManifestBackups(ctx: PubmContext): void {
   for (const pkg of ctx.config.packages) {
     const absPath = path.resolve(ctx.cwd, pkg.path);
-    const ecosystem = requirePackageEcosystem(pkg);
-    const descriptor = ecosystemCatalog.get(ecosystem);
+    const descriptor = ecosystemCatalog.get(pkg.ecosystem);
     if (!descriptor) continue;
     const eco = new descriptor.ecosystemClass(absPath);
     for (const manifestFile of eco.manifestFiles()) {
@@ -138,9 +122,9 @@ export function registerTagRollback(ctx: PubmContext, tagName: string): void {
 export function registerRemoteTagRollback(ctx: PubmContext): void {
   const plan = requireVersionPlan(ctx);
   if (plan.mode === "independent") {
-    for (const [pkgPath, pkgVersion] of plan.packages) {
-      if (isReleaseExcluded(ctx.config, pkgPath)) continue;
-      const pkgName = getPackageName(ctx, pkgPath);
+    for (const [key, pkgVersion] of plan.packages) {
+      if (isReleaseExcluded(ctx.config, pathFromKey(key))) continue;
+      const pkgName = getPackageName(ctx, key);
       const tag = `${pkgName}@${pkgVersion}`;
       ctx.runtime.rollback.add({
         label: t("task.push.deleteRemoteTag", { tag }),

--- a/packages/core/src/tasks/runner-utils/rollback-handlers.ts
+++ b/packages/core/src/tasks/runner-utils/rollback-handlers.ts
@@ -18,7 +18,10 @@ export function isReleaseExcluded(
 }
 
 export function getPackageName(ctx: PubmContext, key: string): string {
-  return ctx.config.packages.find((p) => packageKey(p) === key)?.name ?? key;
+  return (
+    ctx.config.packages.find((p) => packageKey(p) === key)?.name ??
+    pathFromKey(key)
+  );
 }
 
 export function requireVersionPlan(ctx: PubmContext) {

--- a/packages/core/src/tasks/runner-utils/version-pr.ts
+++ b/packages/core/src/tasks/runner-utils/version-pr.ts
@@ -86,7 +86,7 @@ export function buildPrBodyFromContext(
   if (plan.mode === "independent") {
     for (const [key, pkgVersion] of plan.packages) {
       const pkgConfig = ctx.config.packages.find((p) => packageKey(p) === key);
-      const name = pkgConfig?.name ?? key;
+      const name = pkgConfig?.name ?? pathFromKey(key);
       packages.push({ name, version: pkgVersion, bump: "" });
 
       const changelogDir = pkgConfig

--- a/packages/core/src/tasks/runner-utils/version-pr.ts
+++ b/packages/core/src/tasks/runner-utils/version-pr.ts
@@ -6,6 +6,7 @@ import type { PubmContext, VersionPlan } from "../../context.js";
 import { AbstractError } from "../../error.js";
 import { Git } from "../../git.js";
 import { t } from "../../i18n/index.js";
+import { packageKey, pathFromKey } from "../../utils/package-key.js";
 import { parseOwnerRepo } from "../../utils/parse-owner-repo.js";
 import { closeVersionPr, createVersionPr } from "../create-version-pr.js";
 import { buildVersionPrBody } from "../version-pr-body.js";
@@ -83,14 +84,14 @@ export function buildPrBodyFromContext(
   const changelogs = new Map<string, string>();
 
   if (plan.mode === "independent") {
-    for (const [pkgPath, pkgVersion] of plan.packages) {
-      const pkgConfig = ctx.config.packages.find((p) => p.path === pkgPath);
-      const name = pkgConfig?.name ?? pkgPath;
+    for (const [key, pkgVersion] of plan.packages) {
+      const pkgConfig = ctx.config.packages.find((p) => packageKey(p) === key);
+      const name = pkgConfig?.name ?? key;
       packages.push({ name, version: pkgVersion, bump: "" });
 
       const changelogDir = pkgConfig
         ? path.resolve(ctx.cwd, pkgConfig.path)
-        : ctx.cwd;
+        : path.resolve(ctx.cwd, pathFromKey(key));
       const changelogPath = path.join(changelogDir, "CHANGELOG.md");
       if (existsSync(changelogPath)) {
         const section = parseChangelogSection(

--- a/packages/core/src/tasks/runner-utils/write-versions.ts
+++ b/packages/core/src/tasks/runner-utils/write-versions.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 import type { PubmContext } from "../../context.js";
 import { ecosystemCatalog } from "../../ecosystem/catalog.js";
 import { writeVersionsForEcosystem } from "../../manifest/write-versions.js";
-import { requirePackageEcosystem } from "./rollback-handlers.js";
 
 export async function writeVersions(
   ctx: PubmContext,
@@ -10,9 +9,8 @@ export async function writeVersions(
 ): Promise<string[]> {
   const ecosystems = ctx.config.packages.map((pkg) => {
     const absPath = path.resolve(ctx.cwd, pkg.path);
-    const ecosystem = requirePackageEcosystem(pkg);
-    const descriptor = ecosystemCatalog.get(ecosystem);
-    if (!descriptor) throw new Error(`Unknown ecosystem: ${ecosystem}`);
+    const descriptor = ecosystemCatalog.get(pkg.ecosystem);
+    if (!descriptor) throw new Error(`Unknown ecosystem: ${pkg.ecosystem}`);
     const eco = new descriptor.ecosystemClass(absPath);
     return { eco, pkg };
   });

--- a/packages/core/src/tasks/snapshot-runner.ts
+++ b/packages/core/src/tasks/snapshot-runner.ts
@@ -67,7 +67,7 @@ export function buildSnapshotVersionPlan(
     return {
       mode: "single",
       version,
-      packagePath: pkg.path,
+      packageKey: pkg.path,
     } satisfies SingleVersionPlan;
   }
 
@@ -135,7 +135,7 @@ export async function runSnapshotPipeline(
   // Build snapshot version map
   const snapshotVersions: Map<string, string> =
     plan.mode === "single"
-      ? new Map([[plan.packagePath, plan.version]])
+      ? new Map([[plan.packageKey, plan.version]])
       : plan.packages;
 
   // Original versions for restore

--- a/packages/core/src/tasks/snapshot-runner.ts
+++ b/packages/core/src/tasks/snapshot-runner.ts
@@ -16,6 +16,7 @@ import { restoreManifests } from "../monorepo/resolve-workspace.js";
 import { registryCatalog } from "../registry/catalog.js";
 import { exec } from "../utils/exec.js";
 import { createCiListrOptions, createListr } from "../utils/listr.js";
+import { packageKey, pathFromKey } from "../utils/package-key.js";
 import { getPackageManager } from "../utils/package-manager.js";
 import { collectRegistries } from "../utils/registries.js";
 import { generateSnapshotVersion } from "../utils/snapshot.js";
@@ -34,7 +35,7 @@ export function applySnapshotFilter(
 
   const resolver = createKeyResolver(packages);
   const resolvedPaths = new Set(filters.map((f) => resolver(f)));
-  const filtered = packages.filter((p) => resolvedPaths.has(p.path));
+  const filtered = packages.filter((p) => resolvedPaths.has(packageKey(p)));
 
   if (filtered.length === 0) {
     throw new AbstractError(t("error.snapshot.noMatchingPackages"));
@@ -67,7 +68,7 @@ export function buildSnapshotVersionPlan(
     return {
       mode: "single",
       version,
-      packageKey: pkg.path,
+      packageKey: packageKey(pkg),
     } satisfies SingleVersionPlan;
   }
 
@@ -78,7 +79,7 @@ export function buildSnapshotVersionPlan(
       tag,
       template,
     });
-    const pkgMap = new Map(packages.map((p) => [p.path, version]));
+    const pkgMap = new Map(packages.map((p) => [packageKey(p), version]));
     return {
       mode: "fixed",
       version,
@@ -88,7 +89,7 @@ export function buildSnapshotVersionPlan(
 
   const pkgMap = new Map(
     packages.map((p) => [
-      p.path,
+      packageKey(p),
       generateSnapshotVersion({
         baseVersion: p.version || "0.0.0",
         tag,
@@ -140,7 +141,7 @@ export async function runSnapshotPipeline(
 
   // Original versions for restore
   const originalVersions = new Map(
-    targetPackages.map((p) => [p.path, p.version || "0.0.0"]),
+    targetPackages.map((p) => [packageKey(p), p.version || "0.0.0"]),
   );
 
   try {
@@ -217,10 +218,10 @@ export async function runSnapshotPipeline(
             const headCommit = await git.latestCommit();
 
             if (plan.mode === "independent") {
-              for (const [pkgPath, pkgVersion] of plan.packages) {
+              for (const [key, pkgVersion] of plan.packages) {
                 const pkgName =
-                  ctx.config.packages.find((p) => p.path === pkgPath)?.name ??
-                  pkgPath;
+                  ctx.config.packages.find((p) => p.path === pathFromKey(key))
+                    ?.name ?? pathFromKey(key);
                 const tagName = `${pkgName}@${pkgVersion}`;
                 task.output = t("task.snapshot.creatingTag", { tag: tagName });
                 await git.createTag(tagName, headCommit);

--- a/packages/core/src/tasks/snapshot-runner.ts
+++ b/packages/core/src/tasks/snapshot-runner.ts
@@ -220,7 +220,7 @@ export async function runSnapshotPipeline(
             if (plan.mode === "independent") {
               for (const [key, pkgVersion] of plan.packages) {
                 const pkgName =
-                  ctx.config.packages.find((p) => p.path === pathFromKey(key))
+                  ctx.config.packages.find((p) => packageKey(p) === key)
                     ?.name ?? pathFromKey(key);
                 const tagName = `${pkgName}@${pkgVersion}`;
                 task.output = t("task.snapshot.creatingTag", { tag: tagName });

--- a/packages/core/src/utils/crate-graph.ts
+++ b/packages/core/src/utils/crate-graph.ts
@@ -1,4 +1,5 @@
 import { RustEcosystem } from "../ecosystem/rust.js";
+import { pathFromKey } from "./package-key.js";
 
 export async function sortCratesByDependencyOrder(
   cratePaths: string[],
@@ -7,7 +8,8 @@ export async function sortCratesByDependencyOrder(
 
   const crateInfos = await Promise.all(
     cratePaths.map(async (cratePath) => {
-      const eco = new RustEcosystem(cratePath);
+      const realPath = pathFromKey(cratePath);
+      const eco = new RustEcosystem(realPath);
       const name = await eco.packageName();
       const deps = await eco.dependencies();
       return { cratePath, name, deps };

--- a/packages/core/src/utils/filter-config.ts
+++ b/packages/core/src/utils/filter-config.ts
@@ -1,13 +1,14 @@
 import type { ResolvedPubmConfig } from "../config/types.js";
 import type { PubmContext } from "../context.js";
+import { packageKey } from "./package-key.js";
 
 export function filterConfigPackages(
   ctx: PubmContext,
-  publishPaths: Set<string>,
+  publishKeys: Set<string>,
 ): void {
   const filtered: ResolvedPubmConfig = {
     ...ctx.config,
-    packages: ctx.config.packages.filter((p) => publishPaths.has(p.path)),
+    packages: ctx.config.packages.filter((p) => publishKeys.has(packageKey(p))),
   };
   ctx.config = Object.freeze(filtered);
 }

--- a/packages/core/src/utils/package-key.ts
+++ b/packages/core/src/utils/package-key.ts
@@ -1,0 +1,8 @@
+import type { EcosystemKey } from "../ecosystem/catalog.js";
+
+export function packageKey(pkg: {
+  path: string;
+  ecosystem: EcosystemKey;
+}): string {
+  return `${pkg.path}::${pkg.ecosystem}`;
+}

--- a/packages/core/src/utils/package-key.ts
+++ b/packages/core/src/utils/package-key.ts
@@ -6,3 +6,14 @@ export function packageKey(pkg: {
 }): string {
   return `${pkg.path}::${pkg.ecosystem}`;
 }
+
+/**
+ * Extract the filesystem path from a packageKey string (path::ecosystem).
+ * If the key contains no "::" separator, returns the key unchanged.
+ * If key is undefined or empty, returns an empty string.
+ */
+export function pathFromKey(key: string | undefined): string {
+  if (!key) return "";
+  const sep = key.lastIndexOf("::");
+  return sep === -1 ? key : key.slice(0, sep);
+}

--- a/packages/core/tests/unit/changeset/changelog.test.ts
+++ b/packages/core/tests/unit/changeset/changelog.test.ts
@@ -107,6 +107,27 @@ describe("generateChangelog", () => {
     ]);
   });
 
+  it("filters changelog entries by packageKey, not just path", () => {
+    const changesets = [
+      {
+        id: "cs-1",
+        summary: "JS fix.",
+        releases: [{ path: ".", ecosystem: "js", type: "patch" }],
+      },
+      {
+        id: "cs-2",
+        summary: "Rust feature.",
+        releases: [{ path: ".", ecosystem: "rust", type: "minor" }],
+      },
+    ] as any;
+
+    const jsEntries = buildChangelogEntries(changesets, ".::js");
+    expect(jsEntries).toEqual([{ id: "cs-1", summary: "JS fix.", type: "patch" }]);
+
+    const rustEntries = buildChangelogEntries(changesets, ".::rust");
+    expect(rustEntries).toEqual([{ id: "cs-2", summary: "Rust feature.", type: "minor" }]);
+  });
+
   describe("deduplicateEntries", () => {
     it("removes duplicate entries by changeset id", () => {
       expect(

--- a/packages/core/tests/unit/changeset/changelog.test.ts
+++ b/packages/core/tests/unit/changeset/changelog.test.ts
@@ -122,10 +122,14 @@ describe("generateChangelog", () => {
     ] as any;
 
     const jsEntries = buildChangelogEntries(changesets, ".::js");
-    expect(jsEntries).toEqual([{ id: "cs-1", summary: "JS fix.", type: "patch" }]);
+    expect(jsEntries).toEqual([
+      { id: "cs-1", summary: "JS fix.", type: "patch" },
+    ]);
 
     const rustEntries = buildChangelogEntries(changesets, ".::rust");
-    expect(rustEntries).toEqual([{ id: "cs-2", summary: "Rust feature.", type: "minor" }]);
+    expect(rustEntries).toEqual([
+      { id: "cs-2", summary: "Rust feature.", type: "minor" },
+    ]);
   });
 
   describe("deduplicateEntries", () => {

--- a/packages/core/tests/unit/changeset/parser.test.ts
+++ b/packages/core/tests/unit/changeset/parser.test.ts
@@ -14,7 +14,7 @@ Summary text here.`;
     expect(result).toEqual({
       id: "cool-change",
       summary: "Summary text here.",
-      releases: [{ path: "pkg-name", type: "minor" }],
+      releases: [{ path: "pkg-name", ecosystem: undefined, type: "minor" }],
     });
   });
 
@@ -33,9 +33,9 @@ Added a new feature.`;
       id: "multi-pkg",
       summary: "Added a new feature.",
       releases: [
-        { path: "pkg-a", type: "major" },
-        { path: "@scope/pkg-b", type: "patch" },
-        { path: "pkg-c", type: "minor" },
+        { path: "pkg-a", ecosystem: undefined, type: "major" },
+        { path: "@scope/pkg-b", ecosystem: undefined, type: "patch" },
+        { path: "pkg-c", ecosystem: undefined, type: "minor" },
       ],
     });
   });
@@ -119,7 +119,7 @@ Summary.`;
     expect(result).toEqual({
       id: "crlf",
       summary: "Windows line endings.",
-      releases: [{ path: "pkg-name", type: "patch" }],
+      releases: [{ path: "pkg-name", ecosystem: undefined, type: "patch" }],
     });
   });
 
@@ -143,5 +143,22 @@ Summary.`;
     const content = '---\n"packages/core": minor\n---\n\nsome change\n';
     const result = parseChangeset(content, "test.md");
     expect(result.releases[0].path).toBe("packages/core");
+  });
+
+  it("parses new path::ecosystem format", () => {
+    const content = `---\n"packages/core::js": minor\n"packages/cli::rust": patch\n---\n\nMulti-ecosystem change.`;
+    const result = parseChangeset(content, "multi-eco.md");
+    expect(result.releases).toEqual([
+      { path: "packages/core", ecosystem: "js", type: "minor" },
+      { path: "packages/cli", ecosystem: "rust", type: "patch" },
+    ]);
+  });
+
+  it("parses legacy path-only format with ecosystem undefined", () => {
+    const content = `---\n"packages/core": minor\n---\n\nLegacy format.`;
+    const result = parseChangeset(content, "legacy.md");
+    expect(result.releases).toEqual([
+      { path: "packages/core", ecosystem: undefined, type: "minor" },
+    ]);
   });
 });

--- a/packages/core/tests/unit/changeset/resolve.test.ts
+++ b/packages/core/tests/unit/changeset/resolve.test.ts
@@ -3,22 +3,40 @@ import { createKeyResolver } from "../../../src/changeset/resolve.js";
 
 describe("createKeyResolver", () => {
   const packages = [
-    { name: "@pubm/core", path: "packages/core" },
-    { name: "pubm", path: "packages/pubm" },
+    { name: "@pubm/core", path: "packages/core", ecosystem: "js" },
+    { name: "pubm", path: "packages/pubm", ecosystem: "js" },
   ];
 
-  it("returns path unchanged when key is a valid path", () => {
+  it("returns packageKey unchanged when key is already in path::ecosystem format", () => {
     const resolve = createKeyResolver(packages);
-    expect(resolve("packages/core")).toBe("packages/core");
+    expect(resolve("packages/core::js")).toBe("packages/core::js");
   });
 
-  it("converts name to path", () => {
+  it("converts name to packageKey", () => {
     const resolve = createKeyResolver(packages);
-    expect(resolve("@pubm/core")).toBe("packages/core");
+    expect(resolve("@pubm/core")).toBe("packages/core::js");
+  });
+
+  it("auto-resolves legacy path when single ecosystem at that path", () => {
+    const resolve = createKeyResolver(packages);
+    expect(resolve("packages/pubm")).toBe("packages/pubm::js");
   });
 
   it("returns key as-is when no match found", () => {
     const resolve = createKeyResolver(packages);
     expect(resolve("unknown-pkg")).toBe("unknown-pkg");
+  });
+});
+
+describe("createKeyResolver with multi-ecosystem", () => {
+  const packages = [
+    { name: "@pubm/core", path: "packages/core", ecosystem: "js" },
+    { name: "pubm-rs", path: "packages/core", ecosystem: "rust" },
+    { name: "pubm", path: "packages/pubm", ecosystem: "js" },
+  ];
+
+  it("throws for legacy path when multiple ecosystems at that path", () => {
+    const resolve = createKeyResolver(packages);
+    expect(() => resolve("packages/core")).toThrow(/ambiguous/i);
   });
 });

--- a/packages/core/tests/unit/changeset/status.test.ts
+++ b/packages/core/tests/unit/changeset/status.test.ts
@@ -83,6 +83,18 @@ describe("getStatus", () => {
     expect(pkgA!.changesetCount).toBe(3);
   });
 
+  it("tracks status separately for same path with different ecosystems", () => {
+    mockedReadChangesets.mockReturnValue([
+      { id: "change-1", summary: "JS fix.", releases: [{ path: ".", ecosystem: "js", type: "patch" }] },
+      { id: "change-2", summary: "Rust feature.", releases: [{ path: ".", ecosystem: "rust", type: "minor" }] },
+    ]);
+    const result = getStatus("/tmp/project");
+    expect(result.packages.get(".::js")).toBeDefined();
+    expect(result.packages.get(".::js")!.bumpType).toBe("patch");
+    expect(result.packages.get(".::rust")).toBeDefined();
+    expect(result.packages.get(".::rust")!.bumpType).toBe("minor");
+  });
+
   it("tracks multiple packages independently", () => {
     mockedReadChangesets.mockReturnValue([
       {

--- a/packages/core/tests/unit/changeset/status.test.ts
+++ b/packages/core/tests/unit/changeset/status.test.ts
@@ -85,8 +85,16 @@ describe("getStatus", () => {
 
   it("tracks status separately for same path with different ecosystems", () => {
     mockedReadChangesets.mockReturnValue([
-      { id: "change-1", summary: "JS fix.", releases: [{ path: ".", ecosystem: "js", type: "patch" }] },
-      { id: "change-2", summary: "Rust feature.", releases: [{ path: ".", ecosystem: "rust", type: "minor" }] },
+      {
+        id: "change-1",
+        summary: "JS fix.",
+        releases: [{ path: ".", ecosystem: "js", type: "patch" }],
+      },
+      {
+        id: "change-2",
+        summary: "Rust feature.",
+        releases: [{ path: ".", ecosystem: "rust", type: "minor" }],
+      },
     ]);
     const result = getStatus("/tmp/project");
     expect(result.packages.get(".::js")).toBeDefined();

--- a/packages/core/tests/unit/changeset/version.test.ts
+++ b/packages/core/tests/unit/changeset/version.test.ts
@@ -157,10 +157,21 @@ describe("calculateVersionBumps", () => {
 
   it("calculates independent bumps for same path with different ecosystems", () => {
     mockedReadChangesets.mockReturnValue([
-      { id: "c1", summary: "JS fix.", releases: [{ path: ".", ecosystem: "js", type: "patch" }] },
-      { id: "c2", summary: "Rust feature.", releases: [{ path: ".", ecosystem: "rust", type: "minor" }] },
+      {
+        id: "c1",
+        summary: "JS fix.",
+        releases: [{ path: ".", ecosystem: "js", type: "patch" }],
+      },
+      {
+        id: "c2",
+        summary: "Rust feature.",
+        releases: [{ path: ".", ecosystem: "rust", type: "minor" }],
+      },
     ]);
-    const currentVersions = new Map([[".::js", "1.0.0"], [".::rust", "0.5.0"]]);
+    const currentVersions = new Map([
+      [".::js", "1.0.0"],
+      [".::rust", "0.5.0"],
+    ]);
     const result = calculateVersionBumps(currentVersions, "/tmp/project");
     expect(result.get(".::js")?.bumpType).toBe("patch");
     expect(result.get(".::rust")?.bumpType).toBe("minor");

--- a/packages/core/tests/unit/changeset/version.test.ts
+++ b/packages/core/tests/unit/changeset/version.test.ts
@@ -155,6 +155,17 @@ describe("calculateVersionBumps", () => {
     expect(mockedInc).not.toHaveBeenCalled();
   });
 
+  it("calculates independent bumps for same path with different ecosystems", () => {
+    mockedReadChangesets.mockReturnValue([
+      { id: "c1", summary: "JS fix.", releases: [{ path: ".", ecosystem: "js", type: "patch" }] },
+      { id: "c2", summary: "Rust feature.", releases: [{ path: ".", ecosystem: "rust", type: "minor" }] },
+    ]);
+    const currentVersions = new Map([[".::js", "1.0.0"], [".::rust", "0.5.0"]]);
+    const result = calculateVersionBumps(currentVersions, "/tmp/project");
+    expect(result.get(".::js")?.bumpType).toBe("patch");
+    expect(result.get(".::rust")?.bumpType).toBe("minor");
+  });
+
   it("ignores changesets when semver cannot produce a next version", () => {
     mockedReadChangesets.mockReturnValue([
       {

--- a/packages/core/tests/unit/changeset/writer.test.ts
+++ b/packages/core/tests/unit/changeset/writer.test.ts
@@ -61,6 +61,18 @@ describe("generateChangesetContent", () => {
     expect(content).toContain("pkg-a: patch");
     expect(content.endsWith("---\n")).toBe(true);
   });
+
+  it("generates content with path::ecosystem keys", () => {
+    const content = generateChangesetContent(
+      [
+        { path: "packages/core", ecosystem: "js", type: "minor" },
+        { path: "packages/core", ecosystem: "rust", type: "patch" },
+      ],
+      "Multi-ecosystem change.",
+    );
+    expect(content).toContain("packages/core::js: minor");
+    expect(content).toContain("packages/core::rust: patch");
+  });
 });
 
 describe("generateChangesetId", () => {

--- a/packages/core/tests/unit/ecosystem/catalog.test.ts
+++ b/packages/core/tests/unit/ecosystem/catalog.test.ts
@@ -55,16 +55,36 @@ describe("EcosystemCatalog", () => {
   describe("detectAll", () => {
     it("returns empty array when no ecosystem matches", async () => {
       const catalog = new EcosystemCatalog();
-      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(false) }));
-      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(false) }));
+      catalog.register(
+        createDescriptor({
+          key: "js",
+          detect: vi.fn().mockResolvedValue(false),
+        }),
+      );
+      catalog.register(
+        createDescriptor({
+          key: "rust",
+          detect: vi.fn().mockResolvedValue(false),
+        }),
+      );
       const result = await catalog.detectAll("/some/path");
       expect(result).toEqual([]);
     });
 
     it("returns single matching ecosystem", async () => {
       const catalog = new EcosystemCatalog();
-      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(true) }));
-      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(false) }));
+      catalog.register(
+        createDescriptor({
+          key: "js",
+          detect: vi.fn().mockResolvedValue(true),
+        }),
+      );
+      catalog.register(
+        createDescriptor({
+          key: "rust",
+          detect: vi.fn().mockResolvedValue(false),
+        }),
+      );
       const result = await catalog.detectAll("/some/path");
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe("js");
@@ -72,8 +92,18 @@ describe("EcosystemCatalog", () => {
 
     it("returns all matching ecosystems", async () => {
       const catalog = new EcosystemCatalog();
-      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(true) }));
-      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(true) }));
+      catalog.register(
+        createDescriptor({
+          key: "js",
+          detect: vi.fn().mockResolvedValue(true),
+        }),
+      );
+      catalog.register(
+        createDescriptor({
+          key: "rust",
+          detect: vi.fn().mockResolvedValue(true),
+        }),
+      );
       const result = await catalog.detectAll("/some/path");
       expect(result).toHaveLength(2);
       const keys = result.map((d) => d.key);

--- a/packages/core/tests/unit/ecosystem/catalog.test.ts
+++ b/packages/core/tests/unit/ecosystem/catalog.test.ts
@@ -52,24 +52,34 @@ describe("EcosystemCatalog", () => {
     expect(catalog.remove("nonexistent")).toBe(false);
   });
 
-  it("detects ecosystem by calling detect functions in order", async () => {
-    const catalog = new EcosystemCatalog();
-    const jsDetect = vi.fn().mockResolvedValue(false);
-    const rustDetect = vi.fn().mockResolvedValue(true);
-    catalog.register(createDescriptor({ key: "js", detect: jsDetect }));
-    catalog.register(createDescriptor({ key: "rust", detect: rustDetect }));
+  describe("detectAll", () => {
+    it("returns empty array when no ecosystem matches", async () => {
+      const catalog = new EcosystemCatalog();
+      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(false) }));
+      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(false) }));
+      const result = await catalog.detectAll("/some/path");
+      expect(result).toEqual([]);
+    });
 
-    const result = await catalog.detect("/some/path");
-    expect(result?.key).toBe("rust");
-  });
+    it("returns single matching ecosystem", async () => {
+      const catalog = new EcosystemCatalog();
+      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(true) }));
+      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(false) }));
+      const result = await catalog.detectAll("/some/path");
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe("js");
+    });
 
-  it("returns null when no ecosystem detected", async () => {
-    const catalog = new EcosystemCatalog();
-    catalog.register(
-      createDescriptor({ detect: vi.fn().mockResolvedValue(false) }),
-    );
-    const result = await catalog.detect("/empty/path");
-    expect(result).toBeNull();
+    it("returns all matching ecosystems", async () => {
+      const catalog = new EcosystemCatalog();
+      catalog.register(createDescriptor({ key: "js", detect: vi.fn().mockResolvedValue(true) }));
+      catalog.register(createDescriptor({ key: "rust", detect: vi.fn().mockResolvedValue(true) }));
+      const result = await catalog.detectAll("/some/path");
+      expect(result).toHaveLength(2);
+      const keys = result.map((d) => d.key);
+      expect(keys).toContain("js");
+      expect(keys).toContain("rust");
+    });
   });
 });
 

--- a/packages/core/tests/unit/ecosystem/index.test.ts
+++ b/packages/core/tests/unit/ecosystem/index.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/ecosystem/catalog.js", () => {
   const mockCatalog = {
     get: vi.fn(),
-    detect: vi.fn(),
+    detectAll: vi.fn(),
     all: vi.fn().mockReturnValue([]),
     register: vi.fn(),
   };
@@ -13,7 +13,7 @@ vi.mock("../../../src/ecosystem/catalog.js", () => {
 import { ecosystemCatalog } from "../../../src/ecosystem/catalog.js";
 import { detectEcosystem } from "../../../src/ecosystem/index.js";
 
-const mockedEcosystemCatalogDetect = vi.mocked(ecosystemCatalog.detect);
+const mockedEcosystemCatalogDetectAll = vi.mocked(ecosystemCatalog.detectAll);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -27,15 +27,17 @@ describe("detectEcosystem", () => {
         this.packagePath = path;
       }
     }
-    mockedEcosystemCatalogDetect.mockResolvedValue({
-      key: "js",
-      ecosystemClass: MockEcosystem,
-    } as any);
+    mockedEcosystemCatalogDetectAll.mockResolvedValue([
+      {
+        key: "js",
+        ecosystemClass: MockEcosystem,
+      } as any,
+    ]);
 
     const eco = await detectEcosystem("/some/path");
     expect(eco).toBeDefined();
     expect((eco as any).packagePath).toBe("/some/path");
-    expect(mockedEcosystemCatalogDetect).toHaveBeenCalledWith("/some/path");
+    expect(mockedEcosystemCatalogDetectAll).toHaveBeenCalledWith("/some/path");
   });
 
   it("detects Rust ecosystem from manifest", async () => {
@@ -45,19 +47,21 @@ describe("detectEcosystem", () => {
         this.packagePath = path;
       }
     }
-    mockedEcosystemCatalogDetect.mockResolvedValue({
-      key: "rust",
-      ecosystemClass: MockRustEcosystem,
-    } as any);
+    mockedEcosystemCatalogDetectAll.mockResolvedValue([
+      {
+        key: "rust",
+        ecosystemClass: MockRustEcosystem,
+      } as any,
+    ]);
 
     const eco = await detectEcosystem("/rust/path");
     expect(eco).toBeDefined();
     expect((eco as any).packagePath).toBe("/rust/path");
-    expect(mockedEcosystemCatalogDetect).toHaveBeenCalledWith("/rust/path");
+    expect(mockedEcosystemCatalogDetectAll).toHaveBeenCalledWith("/rust/path");
   });
 
   it("returns null when no ecosystem detected", async () => {
-    mockedEcosystemCatalogDetect.mockResolvedValue(null);
+    mockedEcosystemCatalogDetectAll.mockResolvedValue([]);
 
     const eco = await detectEcosystem("/empty/path");
     expect(eco).toBeNull();

--- a/packages/core/tests/unit/manifest/write-versions.test.ts
+++ b/packages/core/tests/unit/manifest/write-versions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ResolvedPackageConfig } from "../../../src/config/types.js";
 import type { Ecosystem } from "../../../src/ecosystem/ecosystem.js";
 import { writeVersionsForEcosystem } from "../../../src/manifest/write-versions.js";
+import { packageKey } from "../../../src/utils/package-key.js";
 
 function createMockEcosystem(name: string, lockfilePath?: string) {
   return {
@@ -40,8 +41,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
@@ -53,7 +54,7 @@ describe("writeVersionsForEcosystem", () => {
     it("skips writeVersion when package has no version in the map", async () => {
       const eco = createMockEcosystem("pkg-a");
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-b", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-b::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
 
@@ -79,7 +80,7 @@ describe("writeVersionsForEcosystem", () => {
       } as unknown as Ecosystem;
 
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
 
@@ -119,8 +120,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
@@ -140,7 +141,7 @@ describe("writeVersionsForEcosystem", () => {
     it("does NOT call updateSiblingDependencyVersions for a single package", async () => {
       const eco = createMockEcosystem("pkg-a");
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
 
@@ -156,7 +157,7 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       // pkg-b has no entry in versions map
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
 
@@ -181,8 +182,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       const result = await writeVersionsForEcosystem(ecosystems, versions);
@@ -199,8 +200,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       const result = await writeVersionsForEcosystem(ecosystems, versions);
@@ -211,7 +212,7 @@ describe("writeVersionsForEcosystem", () => {
     it("returns an empty array when no lockfiles are synced", async () => {
       const eco = createMockEcosystem("pkg-a", undefined);
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       const result = await writeVersionsForEcosystem(ecosystems, versions);
 
@@ -227,8 +228,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
@@ -247,8 +248,8 @@ describe("writeVersionsForEcosystem", () => {
         { eco: ecoB, pkg: createMockPkg("pkg-b") },
       ];
       const versions = new Map([
-        ["/mock/pkg-a", "2.0.0"],
-        ["/mock/pkg-b", "3.0.0"],
+        ["/mock/pkg-a::js", "2.0.0"],
+        ["/mock/pkg-b::js", "3.0.0"],
       ]);
 
       const result = await writeVersionsForEcosystem(ecosystems, versions);
@@ -259,7 +260,7 @@ describe("writeVersionsForEcosystem", () => {
     it("passes lockfileSync mode to syncLockfile", async () => {
       const eco = createMockEcosystem("pkg-a");
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions, "skip");
 
@@ -269,7 +270,7 @@ describe("writeVersionsForEcosystem", () => {
     it("defaults to undefined lockfileSync when not provided", async () => {
       const eco = createMockEcosystem("pkg-a");
       const ecosystems = [{ eco, pkg: createMockPkg("pkg-a") }];
-      const versions = new Map([["/mock/pkg-a", "2.0.0"]]);
+      const versions = new Map([["/mock/pkg-a::js", "2.0.0"]]);
 
       await writeVersionsForEcosystem(ecosystems, versions);
 

--- a/packages/core/tests/unit/manifest/write-versions.test.ts
+++ b/packages/core/tests/unit/manifest/write-versions.test.ts
@@ -25,6 +25,7 @@ function createMockPkg(name: string): ResolvedPackageConfig {
     path: `/mock/${name}`,
     dependencies: [],
     registries: [],
+    ecosystem: "js",
   };
 }
 

--- a/packages/core/tests/unit/monorepo/discover.test.ts
+++ b/packages/core/tests/unit/monorepo/discover.test.ts
@@ -41,9 +41,20 @@ vi.mock("../../../src/ecosystem/catalog.js", async (importOriginal) => {
   return {
     ...original,
     ecosystemCatalog: {
-      detect: vi.fn(),
+      detectAll: vi.fn(),
       get: vi.fn(),
       all: original.ecosystemCatalog.all.bind(original.ecosystemCatalog),
+    },
+  };
+});
+
+vi.mock("../../../src/registry/catalog.js", async (importOriginal) => {
+  const original =
+    (await importOriginal()) as typeof import("../../../src/registry/catalog.js");
+  return {
+    ...original,
+    registryCatalog: {
+      get: vi.fn((key: string) => original.registryCatalog.get(key)),
     },
   };
 });
@@ -58,6 +69,7 @@ import {
   resolvePatterns,
 } from "../../../src/monorepo/discover.js";
 import { detectWorkspace } from "../../../src/monorepo/workspace.js";
+import { registryCatalog } from "../../../src/registry/catalog.js";
 
 const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedStatSync = vi.mocked(statSync);
@@ -65,6 +77,7 @@ const mockedLstatSync = vi.mocked(lstatSync);
 const mockedDetectWorkspace = vi.mocked(detectWorkspace);
 const mockedInferRegistries = vi.mocked(inferRegistries);
 const mockedEcosystemCatalog = vi.mocked(ecosystemCatalog);
+const mockedRegistryCatalog = vi.mocked(registryCatalog);
 
 function createMockEcosystemDescriptor(
   key: string,
@@ -175,7 +188,7 @@ beforeEach(() => {
 describe("discoverPackages", () => {
   it("returns empty array when no workspace, no config packages, and no ecosystem at cwd", async () => {
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(null);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([]);
 
     const result = await discoverPackages({ cwd: "/project" });
 
@@ -191,7 +204,7 @@ describe("discoverPackages", () => {
       { type: "pnpm", patterns: ["packages/*"] },
     ]);
     setupDirectoryEntries(["packages/foo", "packages/bar"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm", "jsr"]);
 
@@ -238,7 +251,7 @@ describe("discoverPackages", () => {
       { type: "pnpm", patterns: ["crates/*"] },
     ]);
     setupDirectoryEntries(["crates/my-crate"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(rustDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([rustDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(rustDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["crates"]);
 
@@ -265,7 +278,7 @@ describe("discoverPackages", () => {
       { type: "pnpm", patterns: ["packages/*"] },
     ]);
     setupDirectoryEntries(["packages/foo", "packages/internal"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
@@ -291,7 +304,7 @@ describe("discoverPackages", () => {
       name: "foo",
       version: "2.0.0",
     });
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
 
     const fooPath = path.join("packages", "foo");
@@ -325,7 +338,7 @@ describe("discoverPackages", () => {
       name: "standalone",
       version: "1.0.0",
     });
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
@@ -370,8 +383,8 @@ describe("discoverPackages", () => {
       ],
     });
 
-    // detect should not be called when ecosystem is explicitly set
-    expect(mockedEcosystemCatalog.detect).not.toHaveBeenCalled();
+    // detectAll should not be called when ecosystem is explicitly set
+    expect(mockedEcosystemCatalog.detectAll).not.toHaveBeenCalled();
 
     expect(result).toEqual([
       {
@@ -390,7 +403,7 @@ describe("discoverPackages", () => {
       { type: "pnpm", patterns: ["packages/*"] },
     ]);
     setupDirectoryEntries(["packages/unknown"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(null);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([]);
 
     const result = await discoverPackages({ cwd: "/project" });
 
@@ -402,7 +415,7 @@ describe("discoverPackages", () => {
       name: "standalone",
       version: "1.0.0",
     });
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm", "jsr"]);
 
@@ -450,12 +463,12 @@ describe("discoverPackages", () => {
     ]);
     setupDirectoryEntries(["packages/public-pkg", "packages/private-pkg"]);
 
-    mockedEcosystemCatalog.detect.mockImplementation(
+    mockedEcosystemCatalog.detectAll.mockImplementation(
       async (pkgPath: string) => {
         if (String(pkgPath).includes("private-pkg")) {
-          return privateDescriptor as any;
+          return [privateDescriptor as any];
         }
-        return publicDescriptor as any;
+        return [publicDescriptor as any];
       },
     );
     mockedEcosystemCatalog.get.mockReturnValue(publicDescriptor as any);
@@ -474,7 +487,7 @@ describe("discoverPackages", () => {
       version: "1.0.0",
     });
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
@@ -499,7 +512,7 @@ describe("discoverPackages", () => {
       private: true,
     });
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
 
     const result = await discoverPackages({ cwd: "/project" });
@@ -509,7 +522,7 @@ describe("discoverPackages", () => {
 
   it("returns empty when no ecosystem detected at cwd", async () => {
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(null);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([]);
 
     const result = await discoverPackages({ cwd: "/project" });
 
@@ -529,7 +542,7 @@ describe("discoverPackages", () => {
       },
     ]);
     setupDirectoryEntries(["crates/included", "crates/excluded"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(rustDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([rustDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(rustDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["crates"]);
 
@@ -550,7 +563,7 @@ describe("discoverPackages", () => {
       registryVersions as Map<string, string>,
     );
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm", "jsr"]);
 
@@ -567,7 +580,7 @@ describe("discoverPackages", () => {
       dependencies: ["dep-a", "dep-b"],
     });
     mockedDetectWorkspace.mockReturnValue([]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedEcosystemCatalog.get.mockReturnValue(jsDescriptor as any);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
@@ -586,7 +599,7 @@ describe("discoverPackages", () => {
       "packages/plugins/plugin-a",
       "packages/plugins/plugin-b",
     ]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
     const result = await discoverPackages({
@@ -620,8 +633,8 @@ describe("discoverPackages", () => {
       expect(pkg.registries).toEqual(["crates"]);
       expect(pkg.ecosystem).toBe("rust");
     }
-    // ecosystemCatalog.get should be used (not detect) since ecosystem is explicit
-    expect(mockedEcosystemCatalog.detect).not.toHaveBeenCalled();
+    // ecosystemCatalog.get should be used (not detectAll) since ecosystem is explicit
+    expect(mockedEcosystemCatalog.detectAll).not.toHaveBeenCalled();
   });
 
   it("filters private packages matched by glob pattern", async () => {
@@ -639,12 +652,12 @@ describe("discoverPackages", () => {
       "packages/plugins/public-plugin",
       "packages/plugins/private-plugin",
     ]);
-    mockedEcosystemCatalog.detect.mockImplementation(
+    mockedEcosystemCatalog.detectAll.mockImplementation(
       async (pkgPath: string) => {
         if (String(pkgPath).includes("private-plugin")) {
-          return privateDescriptor as any;
+          return [privateDescriptor as any];
         }
-        return publicDescriptor as any;
+        return [publicDescriptor as any];
       },
     );
     mockedInferRegistries.mockResolvedValue(["npm"]);
@@ -664,7 +677,7 @@ describe("discoverPackages", () => {
       version: "1.0.0",
     });
     setupDirectoryEntries(["packages/plugins/plugin-a"]);
-    mockedEcosystemCatalog.detect.mockResolvedValue(jsDescriptor as any);
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([jsDescriptor as any]);
     mockedInferRegistries.mockResolvedValue(["npm"]);
 
     const result = await discoverPackages({
@@ -695,6 +708,96 @@ describe("discoverPackages", () => {
     });
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("multi-ecosystem discovery", () => {
+  it("expands path with multiple ecosystems into multiple packages", async () => {
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([
+      createMockEcosystemDescriptor("js", { name: "my-cli", version: "1.0.0" }),
+      createMockEcosystemDescriptor("rust", {
+        name: "my-cli-rs",
+        version: "0.5.0",
+      }),
+    ]);
+    mockedInferRegistries.mockImplementation(async (_path, eco) => {
+      if (eco === "js") return ["npm"];
+      if (eco === "rust") return ["crates"];
+      return [];
+    });
+
+    const result = await discoverPackages({
+      cwd: "/project",
+      configPackages: [{ path: "." }],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.find((p) => p.ecosystem === "js")).toMatchObject({
+      name: "my-cli",
+      version: "1.0.0",
+      registries: ["npm"],
+    });
+    expect(result.find((p) => p.ecosystem === "rust")).toMatchObject({
+      name: "my-cli-rs",
+      version: "0.5.0",
+      registries: ["crates"],
+    });
+  });
+
+  it("filters by explicit ecosystem", async () => {
+    mockedEcosystemCatalog.get.mockReturnValue(
+      createMockEcosystemDescriptor("js", {
+        name: "my-cli",
+        version: "1.0.0",
+      }) as any,
+    );
+    mockedInferRegistries.mockResolvedValue(["npm"]);
+
+    const result = await discoverPackages({
+      cwd: "/project",
+      configPackages: [{ path: ".", ecosystem: "js" }],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ecosystem).toBe("js");
+  });
+
+  it("filters by registries — infers ecosystem from registry", async () => {
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([
+      createMockEcosystemDescriptor("js", { name: "my-cli", version: "1.0.0" }),
+      createMockEcosystemDescriptor("rust", {
+        name: "my-cli-rs",
+        version: "0.5.0",
+      }),
+    ]);
+    mockedRegistryCatalog.get.mockImplementation((key: string) => {
+      if (key === "npm") return { ecosystem: "js" } as any;
+      if (key === "crates") return { ecosystem: "rust" } as any;
+      return undefined;
+    });
+
+    const result = await discoverPackages({
+      cwd: "/project",
+      configPackages: [{ path: ".", registries: ["npm"] }],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ecosystem).toBe("js");
+  });
+
+  it("single ecosystem detected produces single package", async () => {
+    mockedEcosystemCatalog.detectAll.mockResolvedValue([
+      createMockEcosystemDescriptor("js", { name: "my-pkg", version: "1.0.0" }),
+    ]);
+    mockedInferRegistries.mockResolvedValue(["npm"]);
+
+    const result = await discoverPackages({
+      cwd: "/project",
+      configPackages: [{ path: "." }],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ecosystem).toBe("js");
   });
 });
 

--- a/packages/core/tests/unit/tasks/grouping.test.ts
+++ b/packages/core/tests/unit/tasks/grouping.test.ts
@@ -57,18 +57,18 @@ describe("collectEcosystemRegistryGroups", () => {
   it("collects package paths per registry", () => {
     const groups = collectEcosystemRegistryGroups({
       packages: [
-        { path: "packages/a", registries: ["npm"] },
-        { path: "packages/b", registries: ["npm", "jsr"] },
+        { path: "packages/a", registries: ["npm"], ecosystem: "js" },
+        { path: "packages/b", registries: ["npm", "jsr"], ecosystem: "js" },
       ],
     });
     expect(groups).toHaveLength(1);
     expect(groups[0].ecosystem).toBe("js");
     const npmGroup = groups[0].registries.find((r) => r.registry === "npm");
-    expect(npmGroup?.packagePaths).toEqual(
-      expect.arrayContaining(["packages/a", "packages/b"]),
+    expect(npmGroup?.packageKeys).toEqual(
+      expect.arrayContaining(["packages/a::js", "packages/b::js"]),
     );
     const jsrGroup = groups[0].registries.find((r) => r.registry === "jsr");
-    expect(jsrGroup?.packagePaths).toEqual(["packages/b"]);
+    expect(jsrGroup?.packageKeys).toEqual(["packages/b::js"]);
   });
 
   it("deduplicates registries within a single package", () => {

--- a/packages/core/tests/unit/tasks/required-missing-information.test.ts
+++ b/packages/core/tests/unit/tasks/required-missing-information.test.ts
@@ -460,9 +460,9 @@ describe("requiredMissingInformationTasks", () => {
       // pubm selected "keep current" (0.3.6), so it must be filtered out
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
-        packages: new Map([["packages/core", "0.3.7"]]),
+        packages: new Map([["packages/core::js", "0.3.7"]]),
       });
-      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm")).toBe(
+      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm::js")).toBe(
         false,
       );
       expect(
@@ -534,8 +534,8 @@ describe("requiredMissingInformationTasks", () => {
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
         packages: new Map([
-          ["packages/core", "0.3.7"],
-          ["packages/pubm", "0.4.0"],
+          ["packages/core::js", "0.3.7"],
+          ["packages/pubm::js", "0.4.0"],
         ]),
       });
       expect(ctx.runtime.changesetConsumed).toBe(true);
@@ -631,8 +631,8 @@ describe("requiredMissingInformationTasks", () => {
         mode: "fixed",
         version: "1.0.1",
         packages: new Map([
-          ["packages/core", "1.0.1"],
-          ["packages/pubm", "1.0.1"],
+          ["packages/core::js", "1.0.1"],
+          ["packages/pubm::js", "1.0.1"],
         ]),
       });
     });
@@ -674,8 +674,8 @@ describe("requiredMissingInformationTasks", () => {
         mode: "fixed",
         version: "2.0.0",
         packages: new Map([
-          ["packages/core", "2.0.0"],
-          ["packages/pubm", "2.0.0"],
+          ["packages/core::js", "2.0.0"],
+          ["packages/pubm::js", "2.0.0"],
         ]),
       });
       expect(mockTask.output).toContain("1.2.0");
@@ -758,8 +758,8 @@ describe("requiredMissingInformationTasks", () => {
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
         packages: new Map([
-          ["packages/core", "0.4.0"],
-          ["packages/pubm", "0.3.7"],
+          ["packages/core::js", "0.4.0"],
+          ["packages/pubm::js", "0.3.7"],
         ]),
       });
       expect(
@@ -818,12 +818,12 @@ describe("requiredMissingInformationTasks", () => {
       // pkg-a and pkg-b selected "keep current" (0.3.6), so they must be filtered out
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
-        packages: new Map([["packages/core", "0.4.0"]]),
+        packages: new Map([["packages/core::js", "0.4.0"]]),
       });
-      expect(ctx.runtime.versionPlan?.packages.has("packages/pkg-a")).toBe(
+      expect(ctx.runtime.versionPlan?.packages.has("packages/pkg-a::js")).toBe(
         false,
       );
-      expect(ctx.runtime.versionPlan?.packages.has("packages/pkg-b")).toBe(
+      expect(ctx.runtime.versionPlan?.packages.has("packages/pkg-b::js")).toBe(
         false,
       );
       expect(
@@ -877,9 +877,9 @@ describe("requiredMissingInformationTasks", () => {
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
         packages: new Map([
-          ["packages/core", "1.0.1"],
-          ["packages/utils", "2.0.1"],
-          ["packages/app", "3.0.1"],
+          ["packages/core::js", "1.0.1"],
+          ["packages/utils::js", "2.0.1"],
+          ["packages/app::js", "3.0.1"],
         ]),
       });
       expect(
@@ -930,9 +930,9 @@ describe("requiredMissingInformationTasks", () => {
       // pubm selected "keep current" (0.3.6), so it must be filtered out
       expect(ctx.runtime.versionPlan).toMatchObject({
         mode: "independent",
-        packages: new Map([["packages/core", "0.4.0"]]),
+        packages: new Map([["packages/core::js", "0.4.0"]]),
       });
-      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm")).toBe(
+      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm::js")).toBe(
         false,
       );
     });
@@ -1062,8 +1062,10 @@ describe("requiredMissingInformationTasks", () => {
       await versionTask.task(ctx, mockTask);
 
       // Only pkgA (changed) should appear in the plan
-      expect(ctx.runtime.versionPlan?.packages.has("packages/core")).toBe(true);
-      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm")).toBe(
+      expect(ctx.runtime.versionPlan?.packages.has("packages/core::js")).toBe(
+        true,
+      );
+      expect(ctx.runtime.versionPlan?.packages.has("packages/pubm::js")).toBe(
         false,
       );
       // filterConfigPackages must be called with only pkgA's path
@@ -1663,7 +1665,7 @@ describe("requiredMissingInformationTasks", () => {
 
       expect(ctx.runtime.versionPlan).toEqual({
         mode: "independent",
-        packages: new Map([["packages/a", "1.1.0"]]),
+        packages: new Map([["packages/a::js", "1.1.0"]]),
       });
       expect(ctx.runtime.changesetConsumed).toBe(true);
     });
@@ -1695,7 +1697,7 @@ describe("requiredMissingInformationTasks", () => {
       expect(ctx.runtime.versionPlan).toEqual({
         mode: "fixed",
         version: "1.1.0",
-        packages: new Map([["packages/a", "1.1.0"]]),
+        packages: new Map([["packages/a::js", "1.1.0"]]),
       });
       expect(ctx.runtime.changesetConsumed).toBe(true);
     });
@@ -1753,8 +1755,12 @@ describe("requiredMissingInformationTasks", () => {
 
       await versionTask.task(ctx, mockTask);
 
-      expect(ctx.runtime.versionPlan?.packages.get("packages/a")).toBe("1.1.0");
-      expect(ctx.runtime.versionPlan?.packages.get("packages/b")).toBe("2.1.0");
+      expect(ctx.runtime.versionPlan?.packages.get("packages/a::js")).toBe(
+        "1.1.0",
+      );
+      expect(ctx.runtime.versionPlan?.packages.get("packages/b::js")).toBe(
+        "2.1.0",
+      );
       expect(ctx.runtime.changesetConsumed).toBe(true);
     });
 
@@ -1773,7 +1779,9 @@ describe("requiredMissingInformationTasks", () => {
 
       await versionTask.task(ctx, mockTask);
 
-      expect(ctx.runtime.versionPlan?.packages.has("packages/b")).toBe(false);
+      expect(ctx.runtime.versionPlan?.packages.has("packages/b::js")).toBe(
+        false,
+      );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
         new Set(["packages/a"]),
@@ -1909,7 +1917,9 @@ describe("requiredMissingInformationTasks", () => {
       await versionTask.task(ctx, mockTask);
 
       // pkgC should be in the versionPlan with 3.0.1 (patch bump)
-      expect(ctx.runtime.versionPlan?.packages.get("packages/c")).toBe("3.0.1");
+      expect(ctx.runtime.versionPlan?.packages.get("packages/c::js")).toBe(
+        "3.0.1",
+      );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
         new Set(["packages/a", "packages/b", "packages/c"]),
@@ -1966,7 +1976,9 @@ describe("requiredMissingInformationTasks", () => {
       await versionTask.task(ctx, mockTask);
 
       // pkgC should NOT be in the versionPlan (cascade declined)
-      expect(ctx.runtime.versionPlan?.packages.has("packages/c")).toBe(false);
+      expect(ctx.runtime.versionPlan?.packages.has("packages/c::js")).toBe(
+        false,
+      );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
         new Set(["packages/a", "packages/b"]),
@@ -2092,8 +2104,8 @@ describe("requiredMissingInformationTasks", () => {
         mode: "fixed",
         version: "2.1.0",
         packages: new Map([
-          ["packages/a", "2.1.0"],
-          ["packages/b", "2.1.0"],
+          ["packages/a::js", "2.1.0"],
+          ["packages/b::js", "2.1.0"],
         ]),
       });
       expect(ctx.runtime.changesetConsumed).toBe(true);
@@ -2151,8 +2163,12 @@ describe("requiredMissingInformationTasks", () => {
 
       await versionTask.task(ctx, mockTask);
 
-      expect(ctx.runtime.versionPlan?.packages.has("packages/a")).toBe(true);
-      expect(ctx.runtime.versionPlan?.packages.has("packages/b")).toBe(false);
+      expect(ctx.runtime.versionPlan?.packages.has("packages/a::js")).toBe(
+        true,
+      );
+      expect(ctx.runtime.versionPlan?.packages.has("packages/b::js")).toBe(
+        false,
+      );
 
       const filterArg = mockedFilterConfigPackages.mock
         .calls[0][1] as Set<string>;
@@ -2253,10 +2269,18 @@ describe("requiredMissingInformationTasks", () => {
 
       await versionTask.task(ctx, mockTask);
 
-      expect(ctx.runtime.versionPlan?.packages.has("packages/a")).toBe(true);
-      expect(ctx.runtime.versionPlan?.packages.get("packages/a")).toBe("1.1.0");
-      expect(ctx.runtime.versionPlan?.packages.has("packages/c")).toBe(true);
-      expect(ctx.runtime.versionPlan?.packages.get("packages/c")).toBe("2.0.1");
+      expect(ctx.runtime.versionPlan?.packages.has("packages/a::js")).toBe(
+        true,
+      );
+      expect(ctx.runtime.versionPlan?.packages.get("packages/a::js")).toBe(
+        "1.1.0",
+      );
+      expect(ctx.runtime.versionPlan?.packages.has("packages/c::js")).toBe(
+        true,
+      );
+      expect(ctx.runtime.versionPlan?.packages.get("packages/c::js")).toBe(
+        "2.0.1",
+      );
 
       const filterArg = mockedFilterConfigPackages.mock
         .calls[0][1] as Set<string>;

--- a/packages/core/tests/unit/tasks/required-missing-information.test.ts
+++ b/packages/core/tests/unit/tasks/required-missing-information.test.ts
@@ -113,6 +113,7 @@ function makePkg(
     path: overrides.path ?? ".",
     registries: overrides.registries ?? ["npm"],
     dependencies: overrides.dependencies ?? [],
+    ecosystem: overrides.ecosystem ?? "js",
     ...overrides,
   };
 }

--- a/packages/core/tests/unit/tasks/required-missing-information.test.ts
+++ b/packages/core/tests/unit/tasks/required-missing-information.test.ts
@@ -1068,10 +1068,10 @@ describe("requiredMissingInformationTasks", () => {
       expect(ctx.runtime.versionPlan?.packages.has("packages/pubm::js")).toBe(
         false,
       );
-      // filterConfigPackages must be called with only pkgA's path
+      // filterConfigPackages must be called with only pkgA's packageKey
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
-        new Set(["packages/core"]),
+        new Set(["packages/core::js"]),
       );
     });
 
@@ -1784,7 +1784,7 @@ describe("requiredMissingInformationTasks", () => {
       );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
-        new Set(["packages/a"]),
+        new Set(["packages/a::js"]),
       );
     });
 
@@ -1922,7 +1922,7 @@ describe("requiredMissingInformationTasks", () => {
       );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
-        new Set(["packages/a", "packages/b", "packages/c"]),
+        new Set(["packages/a::js", "packages/b::js", "packages/c::js"]),
       );
     });
 
@@ -1981,7 +1981,7 @@ describe("requiredMissingInformationTasks", () => {
       );
       expect(mockedFilterConfigPackages).toHaveBeenCalledWith(
         ctx,
-        new Set(["packages/a", "packages/b"]),
+        new Set(["packages/a::js", "packages/b::js"]),
       );
     });
 
@@ -2172,8 +2172,8 @@ describe("requiredMissingInformationTasks", () => {
 
       const filterArg = mockedFilterConfigPackages.mock
         .calls[0][1] as Set<string>;
-      expect(filterArg.has("packages/a")).toBe(true);
-      expect(filterArg.has("packages/b")).toBe(false);
+      expect(filterArg.has("packages/a::js")).toBe(true);
+      expect(filterArg.has("packages/b::js")).toBe(false);
     });
 
     it("edit → fixed: does NOT call filterConfigPackages", async () => {
@@ -2226,7 +2226,7 @@ describe("requiredMissingInformationTasks", () => {
       expect(mockedFilterConfigPackages).toHaveBeenCalled();
       const filterArg = mockedFilterConfigPackages.mock
         .calls[0][1] as Set<string>;
-      expect(filterArg.has("packages/b")).toBe(false);
+      expect(filterArg.has("packages/b::js")).toBe(false);
     });
 
     it("edit → independent: cascade-accepted packages are included in versionPlan and filterConfigPackages", async () => {
@@ -2284,8 +2284,8 @@ describe("requiredMissingInformationTasks", () => {
 
       const filterArg = mockedFilterConfigPackages.mock
         .calls[0][1] as Set<string>;
-      expect(filterArg.has("packages/a")).toBe(true);
-      expect(filterArg.has("packages/c")).toBe(true);
+      expect(filterArg.has("packages/a::js")).toBe(true);
+      expect(filterArg.has("packages/c::js")).toBe(true);
     });
   });
 

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -594,8 +594,8 @@ describe("runner coverage scenarios", () => {
 
   it("builds dry-run crates tasks sequentially during CI prepare validation", async () => {
     mockedCratesDescriptor.orderPackages.mockResolvedValue([
-      "rust/crates/lib-b",
-      "rust/crates/lib-a",
+      "rust/crates/lib-b::rust",
+      "rust/crates/lib-a::rust",
     ]);
     let ecosystemCall = 0;
     mockedDetectEcosystem.mockImplementation(
@@ -614,9 +614,17 @@ describe("runner coverage scenarios", () => {
         options: { mode: "ci" as const, prepare: true },
         config: {
           packages: [
-            { path: ".", registries: ["npm"] },
-            { path: "rust/crates/lib-a", registries: ["crates"] },
-            { path: "rust/crates/lib-b", registries: ["crates"] },
+            { path: ".", registries: ["npm"], ecosystem: "js" },
+            {
+              path: "rust/crates/lib-a",
+              registries: ["crates"],
+              ecosystem: "rust",
+            },
+            {
+              path: "rust/crates/lib-b",
+              registries: ["crates"],
+              ecosystem: "rust",
+            },
           ],
         },
       }),
@@ -632,9 +640,17 @@ describe("runner coverage scenarios", () => {
     const ctx: any = {
       config: {
         packages: [
-          { path: ".", registries: ["npm"] },
-          { path: "rust/crates/lib-a", registries: ["crates"] },
-          { path: "rust/crates/lib-b", registries: ["crates"] },
+          { path: ".", registries: ["npm"], ecosystem: "js" },
+          {
+            path: "rust/crates/lib-a",
+            registries: ["crates"],
+            ecosystem: "rust",
+          },
+          {
+            path: "rust/crates/lib-b",
+            registries: ["crates"],
+            ecosystem: "rust",
+          },
         ],
       },
       runtime: {
@@ -661,9 +677,9 @@ describe("runner coverage scenarios", () => {
 
     expect(
       mockedCratesDescriptor.taskFactory.createDryRunTask,
-    ).toHaveBeenCalledWith("rust/crates/lib-b", [
-      "rust/crates/lib-a",
-      "rust/crates/lib-b",
+    ).toHaveBeenCalledWith("rust/crates/lib-b::rust", [
+      "rust/crates/lib-a::rust",
+      "rust/crates/lib-b::rust",
     ]);
     expect(innerParent.newListr.mock.calls[0][1]).toEqual({
       concurrent: false,
@@ -672,8 +688,8 @@ describe("runner coverage scenarios", () => {
 
   it("handles independent multi-package version bumps with per-package changelogs and tags", async () => {
     const pathVersions = new Map([
-      ["packages/core", "2.0.0"],
-      ["packages/pubm", "2.1.0"],
+      ["packages/core::js", "2.0.0"],
+      ["packages/pubm::js", "2.1.0"],
     ]);
     const pluginRunner = new PluginRunner([]);
     mockedWriteVersionsForEcosystem.mockResolvedValue([]);
@@ -1520,7 +1536,7 @@ describe("independent release draft", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packageName: "pubm",
+          packageKey: ".::js",
         },
       },
     };
@@ -1622,7 +1638,7 @@ describe("CI GitHub Release", () => {
           versionPlan: {
             mode: "single" as const,
             version: "4.0.0",
-            packageKey: ".",
+            packageKey: ".::js",
           },
         },
       }),
@@ -1652,7 +1668,7 @@ describe("CI GitHub Release", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packageKey: ".",
+          packageKey: ".::js",
         },
       },
     };
@@ -1672,8 +1688,8 @@ describe("CI GitHub Release", () => {
 
   it("creates independent per-package releases in CI with per-package changelog", async () => {
     const pathVersions = new Map([
-      ["packages/core", "2.0.0"],
-      ["packages/pubm", "2.1.0"],
+      ["packages/core::js", "2.0.0"],
+      ["packages/pubm::js", "2.1.0"],
     ]);
     mockedBuildReleaseBody
       .mockResolvedValueOnce("Core release notes")
@@ -3319,8 +3335,8 @@ describe("independent mode GitHub release with null result", () => {
   describe("excludeRelease", () => {
     it("skips tag creation for packages matching excludeRelease patterns", async () => {
       const pathVersions = new Map([
-        ["packages/core", "2.0.0"],
-        ["packages/pubm/platforms/darwin-arm64", "2.0.0"],
+        ["packages/core::js", "2.0.0"],
+        ["packages/pubm/platforms/darwin-arm64::js", "2.0.0"],
       ]);
 
       await run(
@@ -3408,8 +3424,8 @@ describe("independent mode GitHub release with null result", () => {
 
     it("skips GitHub release for packages matching excludeRelease patterns", async () => {
       const pathVersions = new Map([
-        ["packages/core", "2.0.0"],
-        ["packages/pubm/platforms/darwin-arm64", "2.0.0"],
+        ["packages/core::js", "2.0.0"],
+        ["packages/pubm/platforms/darwin-arm64::js", "2.0.0"],
       ]);
       mockedResolveGitHubToken.mockReturnValue({
         token: "gh-token",
@@ -3503,8 +3519,8 @@ describe("independent mode GitHub release with null result", () => {
 
     it("creates tags for all packages when excludeRelease is undefined", async () => {
       const pathVersions = new Map([
-        ["packages/core", "2.0.0"],
-        ["packages/pubm", "2.1.0"],
+        ["packages/core::js", "2.0.0"],
+        ["packages/pubm::js", "2.1.0"],
       ]);
 
       await run(
@@ -3590,8 +3606,8 @@ describe("independent mode GitHub release with null result", () => {
 
     it("skips rollback tag deletion for excluded packages", async () => {
       const pathVersions = new Map([
-        ["packages/core", "2.0.0"],
-        ["packages/pubm/platforms/darwin-arm64", "2.0.0"],
+        ["packages/core::js", "2.0.0"],
+        ["packages/pubm/platforms/darwin-arm64::js", "2.0.0"],
       ]);
 
       await run(
@@ -4389,8 +4405,8 @@ describe("local mode JSR token collection", () => {
 describe("formatVersionSummary and formatVersionPlan edge cases", () => {
   it("formats independent version summary with per-package versions", async () => {
     const pathVersions = new Map([
-      ["packages/core", "2.0.0"],
-      ["packages/pubm", "2.1.0"],
+      ["packages/core::js", "2.0.0"],
+      ["packages/pubm::js", "2.1.0"],
     ]);
 
     await run(
@@ -5592,7 +5608,7 @@ describe("single changeset with pkgPath fallback", () => {
 describe("independent release draft with previousTag fallback", () => {
   it("falls back to firstCommit when previousTag returns empty string", async () => {
     mockedResolveGitHubToken.mockReturnValueOnce(undefined as any);
-    const pathVersions = new Map([["packages/core", "2.0.0"]]);
+    const pathVersions = new Map([["packages/core::js", "2.0.0"]]);
 
     // Set up Git mock
     const gitInstance = {

--- a/packages/core/tests/unit/tasks/runner-coverage.test.ts
+++ b/packages/core/tests/unit/tasks/runner-coverage.test.ts
@@ -392,7 +392,7 @@ function createOptions(
       versionPlan: {
         mode: "single" as const,
         version: "1.0.0",
-        packagePath: ".",
+        packageKey: ".",
       },
       pluginRunner: new PluginRunner([]),
       ...overrides.runtime,
@@ -1622,7 +1622,7 @@ describe("CI GitHub Release", () => {
           versionPlan: {
             mode: "single" as const,
             version: "4.0.0",
-            packagePath: ".",
+            packageKey: ".",
           },
         },
       }),
@@ -1652,7 +1652,7 @@ describe("CI GitHub Release", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -3049,7 +3049,7 @@ describe("dry-run version bump early return", () => {
         versionPlan: {
           mode: "single",
           version: "2.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -4120,7 +4120,7 @@ describe("GitHub release with asset upload hooks", () => {
           versionPlan: {
             mode: "single" as const,
             version: "4.0.0",
-            packagePath: ".",
+            packageKey: ".",
           },
           pluginRunner,
         },
@@ -4163,7 +4163,7 @@ describe("GitHub release with asset upload hooks", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -4196,7 +4196,7 @@ describe("GitHub release with asset upload hooks", () => {
           versionPlan: {
             mode: "single" as const,
             version: "4.0.0",
-            packagePath: ".",
+            packageKey: ".",
           },
         },
       }),
@@ -4229,7 +4229,7 @@ describe("GitHub release with asset upload hooks", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5105,7 +5105,7 @@ describe("GitHub release token prompt paths", () => {
         versionPlan: {
           mode: "single",
           version: "5.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5157,7 +5157,7 @@ describe("GitHub release token prompt paths", () => {
         versionPlan: {
           mode: "single",
           version: "5.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5209,7 +5209,7 @@ describe("GitHub release token prompt paths", () => {
         versionPlan: {
           mode: "single",
           version: "5.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5262,7 +5262,7 @@ describe("GitHub release token prompt paths", () => {
         versionPlan: {
           mode: "single",
           version: "5.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5574,7 +5574,7 @@ describe("single changeset with pkgPath fallback", () => {
         versionPlan: {
           mode: "single",
           version: "4.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5764,7 +5764,7 @@ describe("pushViaPr via push task (buildPrBodyFromContext coverage)", () => {
         versionPlan: {
           mode: "single",
           version: "2.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };
@@ -5996,7 +5996,7 @@ describe("pushViaPr via push task (buildPrBodyFromContext coverage)", () => {
         versionPlan: {
           mode: "single",
           version: "1.0.0",
-          packagePath: ".",
+          packageKey: ".",
         },
       },
     };

--- a/packages/core/tests/unit/tasks/runner.test.ts
+++ b/packages/core/tests/unit/tasks/runner.test.ts
@@ -1785,8 +1785,8 @@ describe("run", () => {
       await run(options);
 
       expect(cratesDescriptor.orderPackages).toHaveBeenCalledWith([
-        "rust/crates/update-kit",
-        "rust/crates/update-kit-cli",
+        "rust/crates/update-kit::rust",
+        "rust/crates/update-kit-cli::rust",
       ]);
     });
 
@@ -1854,8 +1854,12 @@ describe("run", () => {
       const innerSubtasks = (innerParentTask.newListr as any).mock.calls[0][0];
       const innerOptions = (innerParentTask.newListr as any).mock.calls[0][1];
       expect(innerSubtasks).toHaveLength(2);
-      expect(innerSubtasks[0].title).toBe("crates publish (rust/crates/lib-a)");
-      expect(innerSubtasks[1].title).toBe("crates publish (rust/crates/lib-b)");
+      expect(innerSubtasks[0].title).toBe(
+        "crates publish (rust/crates/lib-a::rust)",
+      );
+      expect(innerSubtasks[1].title).toBe(
+        "crates publish (rust/crates/lib-b::rust)",
+      );
       expect(innerOptions.concurrent).toBe(false);
     });
 

--- a/packages/core/tests/unit/tasks/snapshot-runner.test.ts
+++ b/packages/core/tests/unit/tasks/snapshot-runner.test.ts
@@ -236,7 +236,7 @@ describe("buildSnapshotVersionPlan", () => {
     expect(plan).toEqual({
       mode: "single",
       version: "1.0.0-snapshot-20260330T120000",
-      packageKey: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -274,8 +274,8 @@ describe("buildSnapshotVersionPlan", () => {
       mode: "fixed",
       version: "1.0.0-snapshot-20260330T120000",
       packages: new Map([
-        ["packages/a", "1.0.0-snapshot-20260330T120000"],
-        ["packages/b", "1.0.0-snapshot-20260330T120000"],
+        ["packages/a::js", "1.0.0-snapshot-20260330T120000"],
+        ["packages/b::js", "1.0.0-snapshot-20260330T120000"],
       ]),
     });
   });
@@ -313,8 +313,8 @@ describe("buildSnapshotVersionPlan", () => {
     expect(plan).toEqual({
       mode: "independent",
       packages: new Map([
-        ["packages/a", "1.0.0-snapshot-20260330T120000"],
-        ["packages/b", "2.0.0-snapshot-20260330T120000"],
+        ["packages/a::js", "1.0.0-snapshot-20260330T120000"],
+        ["packages/b::js", "2.0.0-snapshot-20260330T120000"],
       ]),
     });
   });
@@ -654,7 +654,7 @@ describe("runSnapshotPipeline", () => {
     // First call: snapshot versions; second call: restore original versions
     expect(writeVersionsCalls).toHaveLength(2);
     // The second call should have the original version "1.0.0"
-    expect(writeVersionsCalls[1]?.get(".")).toBe("1.0.0");
+    expect(writeVersionsCalls[1]?.get(".::js")).toBe("1.0.0");
   });
 
   it("restores original versions even when publish fails", async () => {
@@ -675,7 +675,7 @@ describe("runSnapshotPipeline", () => {
 
     // Should still have restored original versions (finally block)
     expect(writeVersionsCalls).toHaveLength(2);
-    expect(writeVersionsCalls[1]?.get(".")).toBe("1.0.0");
+    expect(writeVersionsCalls[1]?.get(".::js")).toBe("1.0.0");
   });
 
   it("tag task creates git tag and pushes for single/fixed plan", async () => {
@@ -869,8 +869,8 @@ describe("runSnapshotPipeline", () => {
     expect(mockedWriteVersions).toHaveBeenCalled();
     const snapshotVersionsArg = mockedWriteVersions.mock.calls[0]?.[1];
     expect(snapshotVersionsArg).toBeInstanceOf(Map);
-    expect(snapshotVersionsArg?.get("packages/a")).toBe("1.0.0-snap");
-    expect(snapshotVersionsArg?.get("packages/b")).toBe("1.0.0-snap");
+    expect(snapshotVersionsArg?.get("packages/a::js")).toBe("1.0.0-snap");
+    expect(snapshotVersionsArg?.get("packages/b::js")).toBe("1.0.0-snap");
   });
 
   it("tag task uses pkgPath as tag name when pkg name is not found", async () => {

--- a/packages/core/tests/unit/tasks/snapshot-runner.test.ts
+++ b/packages/core/tests/unit/tasks/snapshot-runner.test.ts
@@ -236,7 +236,7 @@ describe("buildSnapshotVersionPlan", () => {
     expect(plan).toEqual({
       mode: "single",
       version: "1.0.0-snapshot-20260330T120000",
-      packagePath: ".",
+      packageKey: ".",
     });
   });
 

--- a/packages/core/tests/unit/utils/filter-config.test.ts
+++ b/packages/core/tests/unit/utils/filter-config.test.ts
@@ -60,9 +60,9 @@ describe("filterConfigPackages", () => {
   const pkgB = makePkg("packages/b", "@scope/b");
   const pkgC = makePkg("packages/c", "@scope/c");
 
-  it("replaces ctx.config.packages with only the packages in publishPaths", () => {
+  it("replaces ctx.config.packages with only the packages in publishKeys", () => {
     const ctx = createContext(makeConfig([pkgA, pkgB, pkgC]), makeOptions());
-    filterConfigPackages(ctx, new Set(["packages/a", "packages/c"]));
+    filterConfigPackages(ctx, new Set(["packages/a::js", "packages/c::js"]));
     expect(ctx.config.packages).toHaveLength(2);
     expect(ctx.config.packages.map((p) => p.path)).toEqual([
       "packages/a",
@@ -72,26 +72,26 @@ describe("filterConfigPackages", () => {
 
   it("freezes the new config object", () => {
     const ctx = createContext(makeConfig([pkgA, pkgB]), makeOptions());
-    filterConfigPackages(ctx, new Set(["packages/a"]));
+    filterConfigPackages(ctx, new Set(["packages/a::js"]));
     expect(Object.isFrozen(ctx.config)).toBe(true);
   });
 
-  it("handles an empty publishPaths set (no packages)", () => {
+  it("handles an empty publishKeys set (no packages)", () => {
     const ctx = createContext(makeConfig([pkgA, pkgB]), makeOptions());
     filterConfigPackages(ctx, new Set());
     expect(ctx.config.packages).toHaveLength(0);
   });
 
-  it("preserves all packages when all paths are in publishPaths", () => {
+  it("preserves all packages when all keys are in publishKeys", () => {
     const ctx = createContext(makeConfig([pkgA, pkgB]), makeOptions());
-    filterConfigPackages(ctx, new Set(["packages/a", "packages/b"]));
+    filterConfigPackages(ctx, new Set(["packages/a::js", "packages/b::js"]));
     expect(ctx.config.packages).toHaveLength(2);
   });
 
   it("preserves other config fields unchanged", () => {
     const ctx = createContext(makeConfig([pkgA, pkgB]), makeOptions());
     const originalBranch = ctx.config.branch;
-    filterConfigPackages(ctx, new Set(["packages/a"]));
+    filterConfigPackages(ctx, new Set(["packages/a::js"]));
     expect(ctx.config.branch).toBe(originalBranch);
   });
 });

--- a/packages/core/tests/unit/utils/filter-config.test.ts
+++ b/packages/core/tests/unit/utils/filter-config.test.ts
@@ -14,6 +14,7 @@ function makePkg(path: string, name: string): ResolvedPackageConfig {
     version: "1.0.0",
     dependencies: [],
     registries: ["npm"],
+    ecosystem: "js",
   };
 }
 

--- a/packages/core/tests/unit/utils/package-key.test.ts
+++ b/packages/core/tests/unit/utils/package-key.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { packageKey } from "../../../src/utils/package-key.js";
+
+describe("packageKey", () => {
+  it("creates composite key from path and ecosystem", () => {
+    expect(packageKey({ path: "packages/core", ecosystem: "js" })).toBe(
+      "packages/core::js",
+    );
+  });
+
+  it("produces different keys for same path with different ecosystem", () => {
+    const jsKey = packageKey({ path: ".", ecosystem: "js" });
+    const rustKey = packageKey({ path: ".", ecosystem: "rust" });
+    expect(jsKey).not.toBe(rustKey);
+  });
+
+  it("produces different keys for different paths with same ecosystem", () => {
+    const a = packageKey({ path: "packages/a", ecosystem: "js" });
+    const b = packageKey({ path: "packages/b", ecosystem: "js" });
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/core/tests/unit/version-plan.test.ts
+++ b/packages/core/tests/unit/version-plan.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { VersionPlan } from "../../src/context.js";
-import { resolveVersion } from "../../src/context.js";
+import type { PubmContext, VersionPlan } from "../../src/context.js";
+import { getPackageVersion, resolveVersion } from "../../src/context.js";
 
 describe("resolveVersion", () => {
   it("returns version for single mode", () => {
     const plan: VersionPlan = {
       mode: "single",
       version: "1.0.0",
-      packagePath: "packages/my-pkg",
+      packageKey: "packages/my-pkg::js",
     };
     expect(resolveVersion(plan)).toBe("1.0.0");
   });
@@ -17,8 +17,8 @@ describe("resolveVersion", () => {
       mode: "fixed",
       version: "2.0.0",
       packages: new Map([
-        ["packages/a", "2.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "2.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     };
     expect(resolveVersion(plan)).toBe("2.0.0");
@@ -28,11 +28,11 @@ describe("resolveVersion", () => {
     const plan: VersionPlan = {
       mode: "independent",
       packages: new Map([
-        ["packages/core", "1.0.0"],
-        ["packages/cli", "2.0.0"],
+        ["packages/core::js", "1.0.0"],
+        ["packages/cli::js", "2.0.0"],
       ]),
     };
-    expect(resolveVersion(plan, (pkgs) => pkgs.get("packages/core")!)).toBe(
+    expect(resolveVersion(plan, (pkgs) => pkgs.get("packages/core::js")!)).toBe(
       "1.0.0",
     );
   });
@@ -40,7 +40,7 @@ describe("resolveVersion", () => {
   it("throws when independent mode has no picker", () => {
     const plan: VersionPlan = {
       mode: "independent",
-      packages: new Map([["packages/a", "1.0.0"]]),
+      packages: new Map([["packages/a::js", "1.0.0"]]),
     };
     expect(() => resolveVersion(plan)).toThrow(
       "independent mode requires an explicit version picker",
@@ -51,7 +51,7 @@ describe("resolveVersion", () => {
     const plan: VersionPlan = {
       mode: "single",
       version: "1.0.0",
-      packagePath: "packages/my-pkg",
+      packageKey: "packages/my-pkg::js",
     };
     expect(resolveVersion(plan, () => "9.9.9")).toBe("1.0.0");
   });
@@ -60,8 +60,67 @@ describe("resolveVersion", () => {
     const plan: VersionPlan = {
       mode: "fixed",
       version: "2.0.0",
-      packages: new Map([["packages/a", "2.0.0"]]),
+      packages: new Map([["packages/a::js", "2.0.0"]]),
     };
     expect(resolveVersion(plan, () => "9.9.9")).toBe("2.0.0");
+  });
+});
+
+describe("getPackageVersion", () => {
+  function makeCtx(plan?: VersionPlan): PubmContext {
+    return {
+      config: {} as PubmContext["config"],
+      options: {} as PubmContext["options"],
+      cwd: "/tmp",
+      runtime: {
+        tag: "latest",
+        promptEnabled: false,
+        cleanWorkingTree: false,
+        pluginRunner: { run: async () => {} } as unknown as PubmContext["runtime"]["pluginRunner"],
+        rollback: { add: () => {} } as unknown as PubmContext["runtime"]["rollback"],
+        versionPlan: plan,
+      },
+    } as unknown as PubmContext;
+  }
+
+  it("returns version for packageKey in independent mode", () => {
+    const plan: VersionPlan = {
+      mode: "independent",
+      packages: new Map([
+        ["pkg-a::js", "1.2.3"],
+        ["pkg-b::rust", "4.5.6"],
+      ]),
+    };
+    const ctx = makeCtx(plan);
+    expect(getPackageVersion(ctx, "pkg-a::js")).toBe("1.2.3");
+    expect(getPackageVersion(ctx, "pkg-b::rust")).toBe("4.5.6");
+    expect(getPackageVersion(ctx, "pkg-c::js")).toBe("");
+  });
+
+  it("returns version for single mode regardless of key", () => {
+    const plan: VersionPlan = {
+      mode: "single",
+      version: "3.0.0",
+      packageKey: "pkg-a::js",
+    };
+    const ctx = makeCtx(plan);
+    expect(getPackageVersion(ctx, "pkg-a::js")).toBe("3.0.0");
+    expect(getPackageVersion(ctx, "any-other-key")).toBe("3.0.0");
+  });
+
+  it("returns version for fixed mode regardless of key", () => {
+    const plan: VersionPlan = {
+      mode: "fixed",
+      version: "5.0.0",
+      packages: new Map([["pkg-a::js", "5.0.0"]]),
+    };
+    const ctx = makeCtx(plan);
+    expect(getPackageVersion(ctx, "pkg-a::js")).toBe("5.0.0");
+    expect(getPackageVersion(ctx, "any-other-key")).toBe("5.0.0");
+  });
+
+  it("returns empty string when no version plan", () => {
+    const ctx = makeCtx(undefined);
+    expect(getPackageVersion(ctx, "pkg-a::js")).toBe("");
   });
 });

--- a/packages/core/tests/unit/version-plan.test.ts
+++ b/packages/core/tests/unit/version-plan.test.ts
@@ -76,8 +76,12 @@ describe("getPackageVersion", () => {
         tag: "latest",
         promptEnabled: false,
         cleanWorkingTree: false,
-        pluginRunner: { run: async () => {} } as unknown as PubmContext["runtime"]["pluginRunner"],
-        rollback: { add: () => {} } as unknown as PubmContext["runtime"]["rollback"],
+        pluginRunner: {
+          run: async () => {},
+        } as unknown as PubmContext["runtime"]["pluginRunner"],
+        rollback: {
+          add: () => {},
+        } as unknown as PubmContext["runtime"]["rollback"],
         versionPlan: plan,
       },
     } as unknown as PubmContext;

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -228,7 +228,7 @@ export function createProgram(): Command {
             ctx.runtime.versionPlan = {
               mode: "single",
               version: nextVersion,
-              packagePath: resolvedConfig.packages[0]?.path ?? ".",
+              packageKey: resolvedConfig.packages[0]?.path ?? ".",
             };
           } else {
             const packages = new Map(
@@ -258,7 +258,7 @@ export function createProgram(): Command {
               ctx.runtime.versionPlan = {
                 mode: "single",
                 version,
-                packagePath: pkg?.path ?? ".",
+                packageKey: pkg?.path ?? ".",
               };
             } else if (resolvedConfig.versioning === "independent") {
               const packages = new Map(
@@ -291,7 +291,7 @@ export function createProgram(): Command {
               ctx.runtime.versionPlan = {
                 mode: "single",
                 version,
-                packagePath: pkg?.path ?? ".",
+                packageKey: pkg?.path ?? ".",
               };
             } else if (resolvedConfig.versioning === "independent") {
               const packages = new Map(
@@ -355,7 +355,7 @@ export function createProgram(): Command {
                 ctx.runtime.versionPlan = {
                   mode: "single",
                   version,
-                  packagePath: pkgPath,
+                  packageKey: pkgPath,
                 };
               } else if (packages.size > 1) {
                 ctx.runtime.versionPlan =

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -354,16 +354,13 @@ export function createProgram(): Command {
             if (recommendations.length > 0) {
               const packages = new Map<string, string>();
               for (const rec of recommendations) {
-                const currentVersion = currentVersions.get(rec.packagePath);
-                if (!currentVersion) continue;
-                const newVersion = semver.inc(currentVersion, rec.bumpType);
-                // Use packageKey as the map key for the version plan
-                const keys = pathToKeys.get(rec.packagePath) ?? [
-                  rec.packagePath,
-                ];
-                if (newVersion) {
-                  for (const key of keys) {
-                    packages.set(key, newVersion);
+                const matchingPkgs = resolvedConfig.packages.filter(
+                  (p) => p.path === rec.packagePath,
+                );
+                for (const pkg of matchingPkgs) {
+                  const newVersion = semver.inc(pkg.version, rec.bumpType);
+                  if (newVersion) {
+                    packages.set(packageKey(pkg), newVersion);
                   }
                 }
               }

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -320,10 +320,13 @@ export function createProgram(): Command {
             const currentVersions = new Map(
               resolvedConfig.packages.map((p) => [p.path, p.version]),
             );
-            // pathToKey maps filesystem path → packageKey for building the version plan
-            const pathToKey = new Map(
-              resolvedConfig.packages.map((p) => [p.path, packageKey(p)]),
-            );
+            // pathToKeys maps filesystem path → packageKey[] for building the version plan
+            const pathToKeys = new Map<string, string[]>();
+            for (const p of resolvedConfig.packages) {
+              const existing = pathToKeys.get(p.path) ?? [];
+              existing.push(packageKey(p));
+              pathToKeys.set(p.path, existing);
+            }
 
             const sources: VersionSource[] = [];
             const versionSources = resolvedConfig.versionSources ?? "all";
@@ -355,8 +358,14 @@ export function createProgram(): Command {
                 if (!currentVersion) continue;
                 const newVersion = semver.inc(currentVersion, rec.bumpType);
                 // Use packageKey as the map key for the version plan
-                const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
-                if (newVersion) packages.set(key, newVersion);
+                const keys = pathToKeys.get(rec.packagePath) ?? [
+                  rec.packagePath,
+                ];
+                if (newVersion) {
+                  for (const key of keys) {
+                    packages.set(key, newVersion);
+                  }
+                }
               }
 
               if (packages.size === 1) {

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -15,6 +15,7 @@ import {
   mergeRecommendations,
   notifyNewVersion,
   PUBM_VERSION,
+  packageKey,
   pubm,
   requiredMissingInformationTasks,
   resolveConfig,
@@ -225,14 +226,15 @@ export function createProgram(): Command {
 
         if (nextVersion) {
           if (resolvedConfig.packages.length <= 1) {
+            const pkg0 = resolvedConfig.packages[0];
             ctx.runtime.versionPlan = {
               mode: "single",
               version: nextVersion,
-              packageKey: resolvedConfig.packages[0]?.path ?? ".",
+              packageKey: pkg0 ? packageKey(pkg0) : ".",
             };
           } else {
             const packages = new Map(
-              resolvedConfig.packages.map((p) => [p.path, nextVersion]),
+              resolvedConfig.packages.map((p) => [packageKey(p), nextVersion]),
             );
             ctx.runtime.versionPlan = {
               mode: "fixed",
@@ -258,11 +260,11 @@ export function createProgram(): Command {
               ctx.runtime.versionPlan = {
                 mode: "single",
                 version,
-                packageKey: pkg?.path ?? ".",
+                packageKey: pkg ? packageKey(pkg) : ".",
               };
             } else if (resolvedConfig.versioning === "independent") {
               const packages = new Map(
-                resolvedConfig.packages.map((p) => [p.path, p.version]),
+                resolvedConfig.packages.map((p) => [packageKey(p), p.version]),
               );
               ctx.runtime.versionPlan = {
                 mode: "independent",
@@ -270,7 +272,7 @@ export function createProgram(): Command {
               };
             } else {
               const packages = new Map(
-                resolvedConfig.packages.map((p) => [p.path, p.version]),
+                resolvedConfig.packages.map((p) => [packageKey(p), p.version]),
               );
               const version = [...packages.values()][0];
               ctx.runtime.versionPlan = {
@@ -291,11 +293,11 @@ export function createProgram(): Command {
               ctx.runtime.versionPlan = {
                 mode: "single",
                 version,
-                packageKey: pkg?.path ?? ".",
+                packageKey: pkg ? packageKey(pkg) : ".",
               };
             } else if (resolvedConfig.versioning === "independent") {
               const packages = new Map(
-                resolvedConfig.packages.map((p) => [p.path, p.version]),
+                resolvedConfig.packages.map((p) => [packageKey(p), p.version]),
               );
               ctx.runtime.versionPlan = {
                 mode: "independent",
@@ -303,7 +305,7 @@ export function createProgram(): Command {
               };
             } else {
               const packages = new Map(
-                resolvedConfig.packages.map((p) => [p.path, p.version]),
+                resolvedConfig.packages.map((p) => [packageKey(p), p.version]),
               );
               const version = [...packages.values()][0];
               ctx.runtime.versionPlan = {
@@ -314,8 +316,13 @@ export function createProgram(): Command {
             }
           } else if (isCI && mode === "local") {
             // Backward compatibility: isCI detected but --mode not set
+            // currentVersions is path-keyed for VersionSourceContext compatibility
             const currentVersions = new Map(
               resolvedConfig.packages.map((p) => [p.path, p.version]),
+            );
+            // pathToKey maps filesystem path → packageKey for building the version plan
+            const pathToKey = new Map(
+              resolvedConfig.packages.map((p) => [p.path, packageKey(p)]),
             );
 
             const sources: VersionSource[] = [];
@@ -347,15 +354,17 @@ export function createProgram(): Command {
                 const currentVersion = currentVersions.get(rec.packagePath);
                 if (!currentVersion) continue;
                 const newVersion = semver.inc(currentVersion, rec.bumpType);
-                if (newVersion) packages.set(rec.packagePath, newVersion);
+                // Use packageKey as the map key for the version plan
+                const key = pathToKey.get(rec.packagePath) ?? rec.packagePath;
+                if (newVersion) packages.set(key, newVersion);
               }
 
               if (packages.size === 1) {
-                const [pkgPath, version] = [...packages.entries()][0];
+                const [key, version] = [...packages.entries()][0];
                 ctx.runtime.versionPlan = {
                   mode: "single",
                   version,
-                  packageKey: pkgPath,
+                  packageKey: key,
                 };
               } else if (packages.size > 1) {
                 ctx.runtime.versionPlan =

--- a/packages/pubm/src/commands/add.ts
+++ b/packages/pubm/src/commands/add.ts
@@ -5,7 +5,13 @@ import type {
   Release,
   ResolvedPubmConfig,
 } from "@pubm/core";
-import { createKeyResolver, t, ui, writeChangeset } from "@pubm/core";
+import {
+  createKeyResolver,
+  packageKey,
+  t,
+  ui,
+  writeChangeset,
+} from "@pubm/core";
 import type { Command } from "commander";
 import Enquirer from "enquirer";
 
@@ -79,13 +85,19 @@ export function registerAddCommand(
           console.log(`\u{1F4E6} ${pkg.name} (v${pkg.version})`);
         } else {
           const isFixed = config.versioning === "fixed";
-          const choices = availablePackages.map((pkg) => ({
-            name: pkg.name,
-            message: `${pkg.name} (v${pkg.version})`,
-            value: pkg.name,
-          }));
+          const choices = availablePackages.map((pkg) => {
+            const key = packageKey({
+              path: pkg.path,
+              ecosystem: pkg.ecosystem,
+            });
+            return {
+              name: key,
+              message: `${pkg.name} (v${pkg.version}) [${pkg.ecosystem}]`,
+              value: key,
+            };
+          });
 
-          const { packages: selectedNames } = await Enquirer.prompt<{
+          const { packages: selectedKeys } = await Enquirer.prompt<{
             packages: string[];
           }>({
             type: "multiselect",
@@ -93,17 +105,25 @@ export function registerAddCommand(
             message: t("prompt.add.selectPackages"),
             choices,
             ...(isFixed && {
-              initial: availablePackages.map((pkg) => pkg.name),
+              initial: availablePackages.map((pkg) =>
+                packageKey({
+                  path: pkg.path,
+                  ecosystem: pkg.ecosystem,
+                }),
+              ),
             }),
           });
 
-          if (selectedNames.length === 0) {
+          if (selectedKeys.length === 0) {
             ui.warn(t("cmd.add.noPackages"));
             return;
           }
 
+          const selectedKeySet = new Set(selectedKeys);
           selectedPackages = availablePackages.filter((pkg) =>
-            selectedNames.includes(pkg.name),
+            selectedKeySet.has(
+              packageKey({ path: pkg.path, ecosystem: pkg.ecosystem }),
+            ),
           );
         }
 

--- a/packages/pubm/src/commands/add.ts
+++ b/packages/pubm/src/commands/add.ts
@@ -1,5 +1,10 @@
 import process from "node:process";
-import type { BumpType, Release, ResolvedPubmConfig } from "@pubm/core";
+import type {
+  BumpType,
+  EcosystemKey,
+  Release,
+  ResolvedPubmConfig,
+} from "@pubm/core";
 import { createKeyResolver, t, ui, writeChangeset } from "@pubm/core";
 import type { Command } from "commander";
 import Enquirer from "enquirer";
@@ -55,12 +60,14 @@ export function registerAddCommand(
           name: string;
           path: string;
           version: string;
+          ecosystem: EcosystemKey;
         }
 
         const availablePackages: PackageInfo[] = config.packages.map((p) => ({
           name: p.name,
           path: p.path,
           version: p.version,
+          ecosystem: p.ecosystem,
         }));
 
         // Step 1: Package selection
@@ -120,7 +127,11 @@ export function registerAddCommand(
           });
 
           for (const pkg of selectedPackages) {
-            releases.push({ path: pkg.path, type: bumpType as BumpType });
+            releases.push({
+              path: pkg.path,
+              ecosystem: pkg.ecosystem,
+              type: bumpType as BumpType,
+            });
           }
         } else {
           for (const pkg of selectedPackages) {
@@ -133,7 +144,11 @@ export function registerAddCommand(
               choices: bumpChoices,
             });
 
-            releases.push({ path: pkg.path, type: bumpType as BumpType });
+            releases.push({
+              path: pkg.path,
+              ecosystem: pkg.ecosystem,
+              type: bumpType as BumpType,
+            });
           }
         }
 

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -22,6 +22,7 @@ import {
   ecosystemCatalog,
   Git,
   mergeRecommendations,
+  packageKey,
   renderChangelog,
   resolveGroups,
   t,
@@ -168,9 +169,11 @@ export async function runVersionCommand(
 
   // 7. Write versions to manifest files via ecosystem
   const ecosystems = buildEcosystems(config.packages, bumps, cwd);
+  // Build packageKey-keyed version map for writeVersionsForEcosystem
   const versions = new Map<string, string>();
   for (const [pkgPath, bump] of bumps) {
-    versions.set(pkgPath, bump.newVersion);
+    const pkg = config.packages.find((p) => p.path === pkgPath);
+    if (pkg) versions.set(packageKey(pkg), bump.newVersion);
   }
   await writeVersionsForEcosystem(ecosystems, versions, config.lockfileSync);
 

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -118,7 +118,7 @@ export async function runVersionCommand(
       for (const group of resolvedFixed) {
         applyFixedGroup(bumpTypes, group);
       }
-      reapplyBumpTypes(bumps, bumpTypes, config.packages, currentVersions);
+      reapplyBumpTypes(bumps, bumpTypes, config.packages);
     }
 
     if (config.linked && config.linked.length > 0) {
@@ -127,7 +127,7 @@ export async function runVersionCommand(
       for (const group of resolvedLinked) {
         applyLinkedGroup(bumpTypes, group);
       }
-      reapplyBumpTypes(bumps, bumpTypes, config.packages, currentVersions);
+      reapplyBumpTypes(bumps, bumpTypes, config.packages);
     }
   }
 
@@ -251,24 +251,24 @@ function reapplyBumpTypes(
   bumps: Map<string, VersionBump>,
   bumpTypes: Map<string, BumpType>,
   packages: ResolvedPackageConfig[],
-  currentVersions: Map<string, string>,
 ): void {
   for (const [name, bumpType] of bumpTypes) {
-    const pkg = packages.find((p) => p.name === name);
-    if (!pkg) continue;
-    const pkgKey = packageKey(pkg);
-    const existing = bumps.get(pkgKey);
-    const currentVersion = currentVersions.get(pkg.path);
-    if (!currentVersion) continue;
+    const matchingPkgs = packages.filter((p) => p.name === name);
+    for (const pkg of matchingPkgs) {
+      const pkgKey = packageKey(pkg);
+      const existing = bumps.get(pkgKey);
+      const currentVersion = pkg.version;
+      if (!currentVersion) continue;
 
-    const newVersion = inc(currentVersion, bumpType);
-    if (!newVersion) continue;
+      const newVersion = inc(currentVersion, bumpType);
+      if (!newVersion) continue;
 
-    if (existing) {
-      existing.bumpType = bumpType;
-      existing.newVersion = newVersion;
-    } else {
-      bumps.set(pkgKey, { currentVersion, newVersion, bumpType });
+      if (existing) {
+        existing.bumpType = bumpType;
+        existing.newVersion = newVersion;
+      } else {
+        bumps.set(pkgKey, { currentVersion, newVersion, bumpType });
+      }
     }
   }
 }

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -85,17 +85,16 @@ export async function runVersionCommand(
   // 4. Convert recommendations to VersionBump map (keyed by packageKey)
   const bumps = new Map<string, VersionBump>();
   for (const rec of recommendations) {
-    const currentVersion = currentVersions.get(rec.packagePath);
-    if (!currentVersion) continue;
-    const newVersion = inc(currentVersion, rec.bumpType);
-    if (!newVersion) continue;
     const matchingPkgs = config.packages.filter(
       (p) => p.path === rec.packagePath,
     );
     for (const pkg of matchingPkgs) {
+      const pkgCurrentVersion = pkg.version;
+      const pkgNewVersion = inc(pkgCurrentVersion, rec.bumpType);
+      if (!pkgNewVersion) continue;
       bumps.set(packageKey(pkg), {
-        currentVersion,
-        newVersion,
+        currentVersion: pkgCurrentVersion,
+        newVersion: pkgNewVersion,
         bumpType: rec.bumpType,
       });
     }

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -89,13 +89,16 @@ export async function runVersionCommand(
     if (!currentVersion) continue;
     const newVersion = inc(currentVersion, rec.bumpType);
     if (!newVersion) continue;
-    const pkg = config.packages.find((p) => p.path === rec.packagePath);
-    if (!pkg) continue;
-    bumps.set(packageKey(pkg), {
-      currentVersion,
-      newVersion,
-      bumpType: rec.bumpType,
-    });
+    const matchingPkgs = config.packages.filter(
+      (p) => p.path === rec.packagePath,
+    );
+    for (const pkg of matchingPkgs) {
+      bumps.set(packageKey(pkg), {
+        currentVersion,
+        newVersion,
+        bumpType: rec.bumpType,
+      });
+    }
   }
 
   if (bumps.size === 0) {

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -245,15 +245,19 @@ function extractBumpTypes(
 }
 
 /**
- * Writes name-keyed bump types back to the packageKey-keyed bumps map.
+ * Writes bump types back to the packageKey-keyed bumps map.
+ * Keys can be either package names or packageKeys (path::ecosystem).
+ * A packageKey matches exactly one package; a name may match multiple.
  */
 function reapplyBumpTypes(
   bumps: Map<string, VersionBump>,
   bumpTypes: Map<string, BumpType>,
   packages: ResolvedPackageConfig[],
 ): void {
-  for (const [name, bumpType] of bumpTypes) {
-    const matchingPkgs = packages.filter((p) => p.name === name);
+  for (const [key, bumpType] of bumpTypes) {
+    const matchingPkgs = key.includes("::")
+      ? packages.filter((p) => packageKey(p) === key)
+      : packages.filter((p) => p.name === key);
     for (const pkg of matchingPkgs) {
       const pkgKey = packageKey(pkg);
       const existing = bumps.get(pkgKey);

--- a/packages/pubm/src/commands/version-cmd.ts
+++ b/packages/pubm/src/commands/version-cmd.ts
@@ -82,14 +82,16 @@ export async function runVersionCommand(
     return;
   }
 
-  // 4. Convert recommendations to VersionBump map
+  // 4. Convert recommendations to VersionBump map (keyed by packageKey)
   const bumps = new Map<string, VersionBump>();
   for (const rec of recommendations) {
     const currentVersion = currentVersions.get(rec.packagePath);
     if (!currentVersion) continue;
     const newVersion = inc(currentVersion, rec.bumpType);
     if (!newVersion) continue;
-    bumps.set(rec.packagePath, {
+    const pkg = config.packages.find((p) => p.path === rec.packagePath);
+    if (!pkg) continue;
+    bumps.set(packageKey(pkg), {
       currentVersion,
       newVersion,
       bumpType: rec.bumpType,
@@ -102,25 +104,28 @@ export async function runVersionCommand(
   }
 
   // 5. Apply fixed/linked groups from config
+  // Build a packageKey → pkg lookup for use in reapplyBumpTypes
+  const pkgByKey = new Map(config.packages.map((p) => [packageKey(p), p]));
+
   {
     const allPackages = config.packages.map((p) => p.name);
 
     if (config.fixed && config.fixed.length > 0) {
       const resolvedFixed = resolveGroups(config.fixed, allPackages);
-      const bumpTypes = extractBumpTypes(bumps);
+      const bumpTypes = extractBumpTypes(bumps, pkgByKey);
       for (const group of resolvedFixed) {
         applyFixedGroup(bumpTypes, group);
       }
-      reapplyBumpTypes(bumps, bumpTypes, currentVersions);
+      reapplyBumpTypes(bumps, bumpTypes, config.packages, currentVersions);
     }
 
     if (config.linked && config.linked.length > 0) {
       const resolvedLinked = resolveGroups(config.linked, allPackages);
-      const bumpTypes = extractBumpTypes(bumps);
+      const bumpTypes = extractBumpTypes(bumps, pkgByKey);
       for (const group of resolvedLinked) {
         applyLinkedGroup(bumpTypes, group);
       }
-      reapplyBumpTypes(bumps, bumpTypes, currentVersions);
+      reapplyBumpTypes(bumps, bumpTypes, config.packages, currentVersions);
     }
   }
 
@@ -128,17 +133,19 @@ export async function runVersionCommand(
   const changesetWriter = new ChangesetChangelogWriter();
   const ccWriter = new ConventionalCommitChangelogWriter();
   const changelogs = new Map<string, { pkgPath: string; content: string }>();
-  for (const [pkgPath, bump] of bumps) {
+  for (const [pkgKey, bump] of bumps) {
     const newVersion = bump.newVersion;
 
-    const pkgConfig = config.packages.find((p) => p.path === pkgPath);
-    const displayName = pkgConfig?.name ?? pkgPath;
+    const pkgConfig = config.packages.find((p) => packageKey(p) === pkgKey);
+    const displayName = pkgConfig?.name ?? pkgKey;
     console.log(
       `${displayName}: ${bump.currentVersion} → ${newVersion} (${bump.bumpType})`,
     );
 
     // Generate changelog entries from recommendations for this package
-    const rec = recommendations.find((r) => r.packagePath === pkgPath);
+    const rec = recommendations.find(
+      (r) => r.packagePath === (pkgConfig?.path ?? pkgKey),
+    );
     let changelogContent: string;
     if (rec) {
       const sections =
@@ -160,7 +167,7 @@ export async function runVersionCommand(
     }
 
     const absPath = pkgConfig ? path.resolve(cwd, pkgConfig.path) : cwd;
-    changelogs.set(pkgPath, { pkgPath: absPath, content: changelogContent });
+    changelogs.set(pkgKey, { pkgPath: absPath, content: changelogContent });
   }
 
   if (dryRun) {
@@ -169,12 +176,10 @@ export async function runVersionCommand(
 
   // 7. Write versions to manifest files via ecosystem
   const ecosystems = buildEcosystems(config.packages, bumps, cwd);
-  // Build packageKey-keyed version map for writeVersionsForEcosystem
-  const versions = new Map<string, string>();
-  for (const [pkgPath, bump] of bumps) {
-    const pkg = config.packages.find((p) => p.path === pkgPath);
-    if (pkg) versions.set(packageKey(pkg), bump.newVersion);
-  }
+  // bumps is already packageKey-keyed — pass directly to writeVersionsForEcosystem
+  const versions = new Map(
+    [...bumps].map(([pkgKey, bump]) => [pkgKey, bump.newVersion]),
+  );
   await writeVersionsForEcosystem(ecosystems, versions, config.lockfileSync);
 
   // Write changelogs
@@ -192,8 +197,8 @@ export async function runVersionCommand(
   await git.stage(".");
   const versionCommitMsg = `Version Packages\n\n${[...bumps]
     .map(
-      ([p, bump]) =>
-        `- ${config.packages.find((pkg) => pkg.path === p)?.name ?? p}: ${bump.newVersion}`,
+      ([pkgKey, bump]) =>
+        `- ${config.packages.find((pkg) => packageKey(pkg) === pkgKey)?.name ?? pkgKey}: ${bump.newVersion}`,
     )
     .join("\n")}`;
   await git.commit(versionCommitMsg);
@@ -208,10 +213,10 @@ function buildEcosystems(
   cwd: string,
 ): { eco: Ecosystem; pkg: ResolvedPackageConfig }[] {
   const result: { eco: Ecosystem; pkg: ResolvedPackageConfig }[] = [];
-  for (const [pkgPath] of bumps) {
-    const pkg = packages.find((p) => p.path === pkgPath);
+  for (const [pkgKey] of bumps) {
+    const pkg = packages.find((p) => packageKey(p) === pkgKey);
     if (!pkg) continue;
-    const ecoKey = pkg.ecosystem ?? "js";
+    const ecoKey = pkg.ecosystem;
     const descriptor = ecosystemCatalog.get(ecoKey);
     if (!descriptor) continue;
     const absPath = path.resolve(cwd, pkg.path);
@@ -221,24 +226,37 @@ function buildEcosystems(
   return result;
 }
 
+/**
+ * Extracts a name-keyed bump type map from the packageKey-keyed bumps map.
+ * applyFixedGroup/applyLinkedGroup operate on package names, not packageKeys.
+ */
 function extractBumpTypes(
   bumps: Map<string, VersionBump>,
+  pkgByKey: Map<string, ResolvedPackageConfig>,
 ): Map<string, BumpType> {
   const bumpTypes = new Map<string, BumpType>();
-  for (const [name, bump] of bumps) {
-    bumpTypes.set(name, bump.bumpType);
+  for (const [pkgKey, bump] of bumps) {
+    const pkg = pkgByKey.get(pkgKey);
+    if (pkg) bumpTypes.set(pkg.name, bump.bumpType);
   }
   return bumpTypes;
 }
 
+/**
+ * Writes name-keyed bump types back to the packageKey-keyed bumps map.
+ */
 function reapplyBumpTypes(
   bumps: Map<string, VersionBump>,
   bumpTypes: Map<string, BumpType>,
+  packages: ResolvedPackageConfig[],
   currentVersions: Map<string, string>,
 ): void {
   for (const [name, bumpType] of bumpTypes) {
-    const existing = bumps.get(name);
-    const currentVersion = currentVersions.get(name);
+    const pkg = packages.find((p) => p.name === name);
+    if (!pkg) continue;
+    const pkgKey = packageKey(pkg);
+    const existing = bumps.get(pkgKey);
+    const currentVersion = currentVersions.get(pkg.path);
     if (!currentVersion) continue;
 
     const newVersion = inc(currentVersion, bumpType);
@@ -248,7 +266,7 @@ function reapplyBumpTypes(
       existing.bumpType = bumpType;
       existing.newVersion = newVersion;
     } else {
-      bumps.set(name, { currentVersion, newVersion, bumpType });
+      bumps.set(pkgKey, { currentVersion, newVersion, bumpType });
     }
   }
 }

--- a/packages/pubm/tests/e2e/lockfile-sync.test.ts
+++ b/packages/pubm/tests/e2e/lockfile-sync.test.ts
@@ -106,6 +106,7 @@ describe("lockfile sync — bun workspace", () => {
           version: "1.0.0",
           dependencies: [],
           registries: ["npm"],
+          ecosystem: "js",
         },
       },
       {
@@ -116,13 +117,14 @@ describe("lockfile sync — bun workspace", () => {
           version: "1.0.0",
           dependencies: ["@test/pkg-a"],
           registries: ["npm"],
+          ecosystem: "js",
         },
       },
     ];
 
     const versions = new Map<string, string>([
-      [pkgAPath, "2.0.0"],
-      [pkgBPath, "2.0.0"],
+      [`${pkgAPath}::js`, "2.0.0"],
+      [`${pkgBPath}::js`, "2.0.0"],
     ]);
 
     const modifiedFiles = await writeVersionsForEcosystem(

--- a/packages/pubm/tests/e2e/mixed-ecosystem.test.ts
+++ b/packages/pubm/tests/e2e/mixed-ecosystem.test.ts
@@ -1,7 +1,7 @@
-import path from "node:path";
 import { writeFileSync } from "node:fs";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { e2e, type E2EContext } from "../utils/e2e.js";
+import { type E2EContext, e2e } from "../utils/e2e.js";
 
 describe("mixed-ecosystem", () => {
   let ctx: E2EContext;

--- a/packages/pubm/tests/e2e/mixed-ecosystem.test.ts
+++ b/packages/pubm/tests/e2e/mixed-ecosystem.test.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { writeFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { e2e, type E2EContext } from "../utils/e2e.js";
+
+describe("mixed-ecosystem", () => {
+  let ctx: E2EContext;
+
+  beforeAll(async () => {
+    ctx = await e2e("mixed-ecosystem");
+    await ctx.git.init().add(".").commit("init").done();
+  });
+
+  afterAll(() => ctx.cleanup());
+
+  it("discovers both JS and Rust packages from same directory", async () => {
+    const { exitCode, stdout } = await ctx.run("inspect", "packages");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("my-cli");
+    expect(stdout).toContain("my-cli-rs");
+  });
+
+  it("discovers only JS when ecosystem is explicit", async () => {
+    const configContent = `export default { packages: [{ path: ".", ecosystem: "js" }] };\n`;
+    writeFileSync(path.join(ctx.dir, "pubm.config.ts"), configContent);
+
+    const { exitCode, stdout } = await ctx.run("inspect", "packages");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("my-cli");
+    expect(stdout).not.toContain("my-cli-rs");
+
+    // Restore original config
+    const originalConfig = `export default { packages: [{ path: "." }] };\n`;
+    writeFileSync(path.join(ctx.dir, "pubm.config.ts"), originalConfig);
+  });
+});

--- a/packages/pubm/tests/fixtures/mixed-ecosystem/Cargo.toml
+++ b/packages/pubm/tests/fixtures/mixed-ecosystem/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "my-cli-rs"
+version = "0.5.0"
+edition = "2021"

--- a/packages/pubm/tests/fixtures/mixed-ecosystem/package.json
+++ b/packages/pubm/tests/fixtures/mixed-ecosystem/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-cli",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/packages/pubm/tests/fixtures/mixed-ecosystem/pubm.config.ts
+++ b/packages/pubm/tests/fixtures/mixed-ecosystem/pubm.config.ts
@@ -1,0 +1,3 @@
+export default {
+  packages: [{ path: "." }],
+};

--- a/packages/pubm/tests/unit/cli.test.ts
+++ b/packages/pubm/tests/unit/cli.test.ts
@@ -38,6 +38,7 @@ const {
         path: ".",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ],
     versionSources: "all",
@@ -198,6 +199,7 @@ beforeEach(() => {
       path: ".",
       registries: ["npm"],
       dependencies: [],
+      ecosystem: "js",
     },
   ];
   sharedResolvedConfig.versionSources = "all";
@@ -333,7 +335,7 @@ describe("CLI action handler - non-CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "1.2.3",
-      packagePath: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -374,6 +376,7 @@ describe("CLI action handler - non-CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -381,6 +384,7 @@ describe("CLI action handler - non-CI mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -391,8 +395,8 @@ describe("CLI action handler - non-CI mode", () => {
       mode: "fixed",
       version: "2.0.0",
       packages: new Map([
-        ["packages/a", "2.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "2.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     });
   });
@@ -408,6 +412,7 @@ describe("CLI action handler - CI mode", () => {
         path: ".",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -417,7 +422,7 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "2.0.0",
-      packagePath: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -430,6 +435,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -437,6 +443,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -447,8 +454,8 @@ describe("CLI action handler - CI mode", () => {
       mode: "fixed",
       version: "2.0.0",
       packages: new Map([
-        ["packages/a", "2.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "2.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     });
   });
@@ -463,6 +470,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -470,6 +478,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -479,8 +488,8 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "independent",
       packages: new Map([
-        ["packages/a", "1.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "1.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     });
   });
@@ -533,7 +542,7 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "1.2.3",
-      packagePath: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -546,6 +555,7 @@ describe("CLI action handler - CI mode", () => {
         path: ".",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
     mockMergeRecommendations.mockReturnValue([
@@ -559,7 +569,7 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "1.1.0",
-      packagePath: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -573,6 +583,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -580,6 +591,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
     mockMergeRecommendations.mockReturnValue([
@@ -595,8 +607,8 @@ describe("CLI action handler - CI mode", () => {
       mode: "fixed",
       version: "2.0.0",
       packages: new Map([
-        ["packages/a", "2.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "2.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     });
   });
@@ -611,6 +623,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -618,6 +631,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
     mockMergeRecommendations.mockReturnValue([
@@ -632,8 +646,8 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "independent",
       packages: new Map([
-        ["packages/a", "1.1.0"],
-        ["packages/b", "2.3.1"],
+        ["packages/a::js", "1.1.0"],
+        ["packages/b::js", "2.3.1"],
       ]),
     });
   });
@@ -648,7 +662,7 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "",
-      packagePath: ".",
+      packageKey: ".",
     });
   });
 
@@ -661,6 +675,7 @@ describe("CLI action handler - CI mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
     mockMergeRecommendations.mockReturnValue([
@@ -681,7 +696,7 @@ describe("CLI action handler - CI mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "2.0.0",
-      packagePath: "packages/a",
+      packageKey: "packages/a::js",
     });
   });
 
@@ -741,6 +756,7 @@ describe("CLI action handler - local publish-only mode", () => {
         path: ".",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -750,7 +766,7 @@ describe("CLI action handler - local publish-only mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "3.0.0",
-      packagePath: ".",
+      packageKey: ".::js",
     });
   });
 
@@ -763,6 +779,7 @@ describe("CLI action handler - local publish-only mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -770,6 +787,7 @@ describe("CLI action handler - local publish-only mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -779,8 +797,8 @@ describe("CLI action handler - local publish-only mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "independent",
       packages: new Map([
-        ["packages/a", "1.0.0"],
-        ["packages/b", "2.0.0"],
+        ["packages/a::js", "1.0.0"],
+        ["packages/b::js", "2.0.0"],
       ]),
     });
   });
@@ -793,6 +811,7 @@ describe("CLI action handler - local publish-only mode", () => {
         path: "packages/a",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
       {
         name: "pkg-b",
@@ -800,6 +819,7 @@ describe("CLI action handler - local publish-only mode", () => {
         path: "packages/b",
         registries: ["npm"],
         dependencies: [],
+        ecosystem: "js",
       },
     ];
 
@@ -810,8 +830,8 @@ describe("CLI action handler - local publish-only mode", () => {
       mode: "fixed",
       version: "4.0.0",
       packages: new Map([
-        ["packages/a", "4.0.0"],
-        ["packages/b", "4.0.0"],
+        ["packages/a::js", "4.0.0"],
+        ["packages/b::js", "4.0.0"],
       ]),
     });
   });
@@ -825,7 +845,7 @@ describe("CLI action handler - local publish-only mode", () => {
     expect(ctx.runtime.versionPlan).toEqual({
       mode: "single",
       version: "",
-      packagePath: ".",
+      packageKey: ".",
     });
   });
 });

--- a/packages/pubm/tests/unit/commands/add.test.ts
+++ b/packages/pubm/tests/unit/commands/add.test.ts
@@ -18,6 +18,8 @@ const {
 vi.mock("@pubm/core", () => ({
   writeChangeset: mockWriteChangeset,
   createKeyResolver: mockCreateKeyResolver,
+  packageKey: (pkg: { path: string; ecosystem: string }) =>
+    `${pkg.path}::${pkg.ecosystem}`,
   ui: {
     success: mockUiSuccess,
     warn: mockUiWarn,
@@ -43,11 +45,19 @@ function makeParent(): Command {
 }
 
 function makeConfig(
-  packages: { name: string; path: string; version: string }[] = [],
+  packages: {
+    name: string;
+    path: string;
+    version: string;
+    ecosystem?: string;
+  }[] = [],
   versioning: "independent" | "fixed" = "independent",
 ) {
   return {
-    packages,
+    packages: packages.map((p) => ({
+      ...p,
+      ecosystem: p.ecosystem ?? "js",
+    })),
     versioning,
   } as never;
 }
@@ -141,7 +151,7 @@ describe("registerAddCommand", () => {
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining("pkg-a"));
     expect(mockWriteChangeset).toHaveBeenCalledWith(
-      [{ path: "packages/a", type: "patch" }],
+      [{ path: "packages/a", ecosystem: "js", type: "patch" }],
       "fix: a bug",
       expect.any(String),
     );
@@ -168,7 +178,9 @@ describe("registerAddCommand", () => {
   it("handles multi-package interactive flow", async () => {
     // For multi-package: package selection, then bump per package, then summary
     mockEnquirerPrompt
-      .mockResolvedValueOnce({ packages: ["pkg-a", "pkg-b"] })
+      .mockResolvedValueOnce({
+        packages: ["packages/a::js", "packages/b::js"],
+      })
       .mockResolvedValueOnce({ bump: "minor" })
       .mockResolvedValueOnce({ bump: "patch" })
       .mockResolvedValueOnce({ summary: "multi-package update" });
@@ -184,8 +196,8 @@ describe("registerAddCommand", () => {
 
     expect(mockWriteChangeset).toHaveBeenCalledWith(
       [
-        { path: "packages/a", type: "minor" },
-        { path: "packages/b", type: "patch" },
+        { path: "packages/a", ecosystem: "js", type: "minor" },
+        { path: "packages/b", ecosystem: "js", type: "patch" },
       ],
       "multi-package update",
       expect.any(String),
@@ -195,7 +207,9 @@ describe("registerAddCommand", () => {
 
   it("pre-selects all packages in fixed mode interactive flow", async () => {
     mockEnquirerPrompt
-      .mockResolvedValueOnce({ packages: ["pkg-a", "pkg-b"] })
+      .mockResolvedValueOnce({
+        packages: ["packages/a::js", "packages/b::js"],
+      })
       .mockResolvedValueOnce({ bump: "minor" })
       .mockResolvedValueOnce({ summary: "fixed bump" });
 
@@ -213,23 +227,25 @@ describe("registerAddCommand", () => {
 
     const firstCall = mockEnquirerPrompt.mock.calls[0][0];
     expect(firstCall.type).toBe("multiselect");
-    expect(firstCall.initial).toEqual(["pkg-a", "pkg-b"]);
+    expect(firstCall.initial).toEqual(["packages/a::js", "packages/b::js"]);
 
     expect(mockEnquirerPrompt).toHaveBeenCalledTimes(3);
 
     expect(mockWriteChangeset).toHaveBeenCalledWith(
       [
-        { path: "packages/a", type: "minor" },
-        { path: "packages/b", type: "minor" },
+        { path: "packages/a", ecosystem: "js", type: "minor" },
+        { path: "packages/b", ecosystem: "js", type: "minor" },
       ],
       "fixed bump",
       expect.any(String),
     );
   });
 
-  it("passes initial with all package names in fixed mode (regression)", async () => {
+  it("passes initial with all package keys in fixed mode (regression)", async () => {
     mockEnquirerPrompt
-      .mockResolvedValueOnce({ packages: ["pkg-a", "pkg-b", "pkg-c"] })
+      .mockResolvedValueOnce({
+        packages: ["packages/a::js", "packages/b::js", "packages/c::js"],
+      })
       .mockResolvedValueOnce({ bump: "patch" })
       .mockResolvedValueOnce({ summary: "regression test" });
 
@@ -244,7 +260,9 @@ describe("registerAddCommand", () => {
     await parent.parseAsync(["node", "test", "add"]);
 
     const firstCall = mockEnquirerPrompt.mock.calls[0][0];
-    expect(firstCall.initial).toEqual(packages.map((pkg) => pkg.name));
+    expect(firstCall.initial).toEqual(
+      packages.map((pkg) => `${pkg.path}::js`),
+    );
     expect(firstCall.choices).not.toContainEqual(
       expect.objectContaining({ enabled: true }),
     );
@@ -252,7 +270,9 @@ describe("registerAddCommand", () => {
 
   it("prompts bump per-package in independent mode", async () => {
     mockEnquirerPrompt
-      .mockResolvedValueOnce({ packages: ["pkg-a", "pkg-b"] })
+      .mockResolvedValueOnce({
+        packages: ["packages/a::js", "packages/b::js"],
+      })
       .mockResolvedValueOnce({ bump: "minor" })
       .mockResolvedValueOnce({ bump: "patch" })
       .mockResolvedValueOnce({ summary: "independent bump" });

--- a/packages/pubm/tests/unit/commands/add.test.ts
+++ b/packages/pubm/tests/unit/commands/add.test.ts
@@ -260,9 +260,7 @@ describe("registerAddCommand", () => {
     await parent.parseAsync(["node", "test", "add"]);
 
     const firstCall = mockEnquirerPrompt.mock.calls[0][0];
-    expect(firstCall.initial).toEqual(
-      packages.map((pkg) => `${pkg.path}::js`),
-    );
+    expect(firstCall.initial).toEqual(packages.map((pkg) => `${pkg.path}::js`));
     expect(firstCall.choices).not.toContainEqual(
       expect.objectContaining({ enabled: true }),
     );

--- a/packages/pubm/tests/unit/commands/version-cmd.test.ts
+++ b/packages/pubm/tests/unit/commands/version-cmd.test.ts
@@ -301,14 +301,9 @@ describe("runVersionCommand", () => {
     });
     mockedResolveGroups.mockReturnValue([["pkg-a", "pkg-b"]]);
     mockedApplyFixedGroup.mockImplementation((bumpTypes, group) => {
-      // Simulate applyFixedGroup by setting minor for both packages
-      const nameToPaths: Record<string, string> = {
-        "pkg-a": "packages/pkg-a",
-        "pkg-b": "packages/pkg-b",
-      };
+      // Simulate applyFixedGroup by setting minor for both packages (name-keyed)
       for (const name of group) {
-        const p = nameToPaths[name] ?? name;
-        bumpTypes.set(p, "minor");
+        bumpTypes.set(name, "minor");
       }
     });
 

--- a/packages/pubm/tests/unit/commands/version-cmd.test.ts
+++ b/packages/pubm/tests/unit/commands/version-cmd.test.ts
@@ -154,7 +154,7 @@ describe("runVersionCommand", () => {
 
     expect(mockedWriteVersionsForEcosystem).toHaveBeenCalledWith(
       expect.any(Array),
-      new Map([[".", "1.1.0"]]),
+      new Map([[".::js", "1.1.0"]]),
       undefined,
     );
     expect(mockChangesetChangelogWriterFormatEntries).toHaveBeenCalledWith([
@@ -321,8 +321,8 @@ describe("runVersionCommand", () => {
     expect(mockedWriteVersionsForEcosystem).toHaveBeenCalledWith(
       expect.any(Array),
       new Map([
-        ["packages/pkg-a", "1.1.0"],
-        ["packages/pkg-b", "1.1.0"],
+        ["packages/pkg-a::js", "1.1.0"],
+        ["packages/pkg-b::js", "1.1.0"],
       ]),
       undefined,
     );


### PR DESCRIPTION
## Summary

Closes #14

- A directory with both `Cargo.toml` and `package.json` now produces independent packages per ecosystem, removing the need for explicit `ecosystem` overrides
- Package identity changed from `path` to `(path, ecosystem)` composite key via `packageKey()` utility
- `EcosystemCatalog.detect()` replaced with `detectAll()` — returns all matching ecosystems instead of first match
- `ecosystem` is now required on `ResolvedPackageConfig`
- Changeset format updated to `path::ecosystem` keys with backward compatibility for legacy path-only format

## Key changes

- **Detection**: `detectAll()` scans all registered ecosystems per directory
- **Discovery**: `resolvePackages()` expands a single config entry into multiple packages when multiple ecosystems are detected
- **Filtering**: explicit `ecosystem` or `registries` in config narrows which ecosystems are resolved
- **Changeset compat**: legacy path-only changeset keys auto-resolve when unambiguous, error when ambiguous

## Test plan

- [x] `packageKey()` unit tests (composite key generation)
- [x] `detectAll()` unit tests (empty, single, multiple matches)
- [x] Multi-ecosystem discovery tests (auto-detect, ecosystem filter, registry filter, combined)
- [x] Changeset parser/writer/resolve tests (new `::` format + legacy compat + ambiguity error)
- [x] Changeset status/version/changelog rekeyed tests
- [x] VersionPlan/getPackageVersion rekeyed tests
- [x] E2E: mixed-ecosystem fixture with `package.json` + `Cargo.toml`
- [x] E2E: all existing tests pass (regression)
- [x] Full typecheck, 421 tests passing, coverage thresholds maintained