### PR TITLE
fix: dry-run validation for workspace crates with internal dependencies

### DIFF
--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -74,6 +74,8 @@ export interface PubmConfig {
   rollbackStrategy?: "individual" | "all";
   rollback?: RollbackConfig;
   lockfileSync?: "required" | "optional" | "skip";
+  /** Skip dry-run validation during prepare phase. @default false */
+  skipDryRun?: boolean;
   ecosystems?: Record<string, EcosystemConfig>;
   plugins?: PubmPlugin[];
   compress?: CompressOption;
@@ -107,6 +109,7 @@ export interface ResolvedPubmConfig
       | "ecosystems"
       | "testScript"
       | "buildScript"
+      | "skipDryRun"
     >
   > {
   compress?: CompressOption;
@@ -123,6 +126,7 @@ export interface ResolvedPubmConfig
   ecosystems: Record<string, EcosystemConfig>;
   testScript?: string;
   buildScript?: string;
+  skipDryRun?: boolean;
   discoveryEmpty?: boolean;
 }
 

--- a/packages/core/src/i18n/locales/de.json
+++ b/packages/core/src/i18n/locales/de.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "Tests vor der Veröffentlichung überspringen",
   "cli.option.noBuild": "Build vor der Veröffentlichung überspringen",
   "cli.option.noPublish": "Veröffentlichungsaufgabe überspringen",
+  "cli.option.noDryRunValidation": "Dry-Run-Validierung in der Vorbereitungsphase überspringen",
   "cli.option.skipRelease": "GitHub Release-Erstellung überspringen",
   "cli.option.tag": "Unter einem bestimmten dist-tag veröffentlichen",
   "cli.option.contents": "Unterverzeichnis zum Veröffentlichen",

--- a/packages/core/src/i18n/locales/en.json
+++ b/packages/core/src/i18n/locales/en.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "Skip running tests before publishing",
   "cli.option.noBuild": "Skip build before publishing",
   "cli.option.noPublish": "Skip publishing task",
+  "cli.option.noDryRunValidation": "Skip dry-run validation during prepare phase",
   "cli.option.skipRelease": "Skip GitHub Release creation",
   "cli.option.tag": "Publish under a specific dist-tag",
   "cli.option.contents": "Subdirectory to publish",

--- a/packages/core/src/i18n/locales/es.json
+++ b/packages/core/src/i18n/locales/es.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "Omitir la ejecución de pruebas antes de publicar",
   "cli.option.noBuild": "Omitir la construcción antes de publicar",
   "cli.option.noPublish": "Omitir la tarea de publicación",
+  "cli.option.noDryRunValidation": "Omitir la validación dry-run durante la fase de preparación",
   "cli.option.skipRelease": "Omitir la creación de GitHub Release",
   "cli.option.tag": "Publicar bajo un dist-tag específico",
   "cli.option.contents": "Subdirectorio a publicar",

--- a/packages/core/src/i18n/locales/fr.json
+++ b/packages/core/src/i18n/locales/fr.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "Ignorer l'exécution des tests avant la publication",
   "cli.option.noBuild": "Ignorer la construction avant la publication",
   "cli.option.noPublish": "Ignorer la tâche de publication",
+  "cli.option.noDryRunValidation": "Ignorer la validation dry-run pendant la phase de préparation",
   "cli.option.skipRelease": "Ignorer la création de la GitHub Release",
   "cli.option.tag": "Publier sous un dist-tag spécifique",
   "cli.option.contents": "Sous-répertoire à publier",

--- a/packages/core/src/i18n/locales/ko.json
+++ b/packages/core/src/i18n/locales/ko.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "배포 전 테스트 실행 건너뜀",
   "cli.option.noBuild": "배포 전 빌드 건너뜀",
   "cli.option.noPublish": "배포 작업 건너뜀",
+  "cli.option.noDryRunValidation": "준비 단계에서 드라이런 검증을 건너뜁니다",
   "cli.option.skipRelease": "GitHub Release 생성 건너뜀",
   "cli.option.tag": "특정 dist-tag로 배포",
   "cli.option.contents": "배포할 하위 디렉토리",

--- a/packages/core/src/i18n/locales/zh-cn.json
+++ b/packages/core/src/i18n/locales/zh-cn.json
@@ -269,6 +269,7 @@
   "cli.option.noTests": "跳过发布前运行测试",
   "cli.option.noBuild": "跳过发布前构建",
   "cli.option.noPublish": "跳过发布任务",
+  "cli.option.noDryRunValidation": "跳过准备阶段的试运行验证",
   "cli.option.skipRelease": "跳过 GitHub Release 创建",
   "cli.option.tag": "以特定 dist-tag 发布",
   "cli.option.contents": "要发布的子目录",

--- a/packages/core/src/tasks/dry-run-publish.ts
+++ b/packages/core/src/tasks/dry-run-publish.ts
@@ -129,28 +129,36 @@ const MISSING_CRATE_PATTERN = /no matching package named `([^`]+)` found/;
 
 async function findUnpublishedSiblingDeps(
   packagePath: string,
-  siblingPaths: string[],
+  siblingKeys: string[],
+  ctx: PubmContext,
 ): Promise<string[]> {
   const eco = new RustEcosystem(packagePath);
   const deps = await eco.dependencies();
 
-  const siblingNameToPath = new Map<string, string>();
+  const siblingNameToKey = new Map<string, string>();
   await Promise.all(
-    siblingPaths.map(async (p) => {
-      const name = await getCrateName(p);
-      siblingNameToPath.set(name, p);
+    siblingKeys.map(async (k) => {
+      const name = await getCrateName(pathFromKey(k));
+      siblingNameToKey.set(name, k);
     }),
   );
 
-  const siblingDeps = deps.filter((d) => siblingNameToPath.has(d));
+  const siblingDeps = deps.filter((d) => siblingNameToKey.has(d));
 
   const results = await Promise.all(
     siblingDeps.map(async (name) => {
-      const siblingPath = siblingNameToPath.get(name);
-      if (!siblingPath) {
-        throw new Error(`Missing sibling crate path for dependency: ${name}`);
+      const siblingKey = siblingNameToKey.get(name);
+      if (!siblingKey) {
+        throw new Error(`Missing sibling crate key for dependency: ${name}`);
       }
+      const siblingPath = pathFromKey(siblingKey);
       const registry = await cratesPackageRegistry(siblingPath);
+      const version = getPackageVersion(ctx, siblingKey);
+      if (version) {
+        const versionPublished = await registry.isVersionPublished(version);
+        return versionPublished ? null : name;
+      }
+      // Fallback: check if the crate exists at all
       const published = await registry.isPublished();
       return published ? null : name;
     }),
@@ -164,7 +172,6 @@ export function createCratesDryRunPublishTask(
   siblingKeys?: string[],
 ): ListrTask<PubmContext> {
   const packagePath = pathFromKey(key);
-  const siblingPaths = siblingKeys?.map(pathFromKey);
   return {
     title: t("task.dryRun.crates.title", { path: packagePath }),
     task: async (ctx, task): Promise<void> => {
@@ -185,11 +192,12 @@ export function createCratesDryRunPublishTask(
         return task.skip();
       }
 
-      // Proactive: skip if any sibling dependency is not yet on crates.io
-      if (siblingPaths?.length) {
+      // Proactive: skip if any sibling dependency's new version is not yet on crates.io
+      if (siblingKeys?.length) {
         const unpublished = await findUnpublishedSiblingDeps(
           packagePath,
-          siblingPaths,
+          siblingKeys,
+          ctx,
         );
         if (unpublished.length > 0) {
           task.title = t("task.dryRun.crates.skippedSibling", {
@@ -210,9 +218,9 @@ export function createCratesDryRunPublishTask(
         // Reactive fallback: catch sibling-related errors
         const message = error instanceof Error ? error.message : String(error);
         const match = message.match(MISSING_CRATE_PATTERN);
-        if (match && siblingPaths) {
+        if (match && siblingKeys) {
           const siblingNames = await Promise.all(
-            siblingPaths.map((p) => getCrateName(p)),
+            siblingKeys.map((k) => getCrateName(pathFromKey(k))),
           );
           if (siblingNames.includes(match[1])) {
             task.title = t("task.dryRun.crates.skippedSibling", {

--- a/packages/core/src/tasks/dry-run-publish.ts
+++ b/packages/core/src/tasks/dry-run-publish.ts
@@ -126,6 +126,8 @@ async function getCrateName(packagePath: string): Promise<string> {
 }
 
 const MISSING_CRATE_PATTERN = /no matching package named `([^`]+)` found/;
+const VERSION_MISMATCH_PATTERN =
+  /failed to select a version for the requirement `([^=`\s]+)/;
 
 async function findUnpublishedSiblingDeps(
   packagePath: string,
@@ -217,15 +219,18 @@ export function createCratesDryRunPublishTask(
       } catch (error) {
         // Reactive fallback: catch sibling-related errors
         const message = error instanceof Error ? error.message : String(error);
-        const match = message.match(MISSING_CRATE_PATTERN);
-        if (match && siblingKeys) {
+        const missingMatch = message.match(MISSING_CRATE_PATTERN);
+        const versionMatch = message.match(VERSION_MISMATCH_PATTERN);
+        const crateName = missingMatch?.[1] ?? versionMatch?.[1]?.trim();
+
+        if (crateName && siblingKeys) {
           const siblingNames = await Promise.all(
             siblingKeys.map((k) => getCrateName(pathFromKey(k))),
           );
-          if (siblingNames.includes(match[1])) {
+          if (siblingNames.includes(crateName)) {
             task.title = t("task.dryRun.crates.skippedSibling", {
               path: packagePath,
-              crate: match[1],
+              crate: crateName,
             });
             return;
           }

--- a/packages/core/src/tasks/phases/dry-run.ts
+++ b/packages/core/src/tasks/phases/dry-run.ts
@@ -21,10 +21,11 @@ export function createDryRunTasks(
   dryRun: boolean,
   mode: string,
   hasPrepare: boolean,
+  skipDryRun: boolean,
 ): ListrTask<PubmContext>[] {
   return [
     {
-      enabled: dryRun || (mode === "ci" && hasPrepare),
+      enabled: !skipDryRun && (dryRun || (mode === "ci" && hasPrepare)),
       title: t("task.dryRunValidation.title"),
       task: async (ctx, parentTask): Promise<Listr<PubmContext>> => {
         await resolveWorkspaceProtocols(ctx);
@@ -47,7 +48,7 @@ export function createDryRunTasks(
       },
     },
     {
-      enabled: dryRun || (mode === "ci" && hasPrepare),
+      enabled: !skipDryRun && (dryRun || (mode === "ci" && hasPrepare)),
       skip: (ctx) => !ctx.runtime.workspaceBackups?.size,
       title: t("task.dryRunValidation.restoreProtocols"),
       task: async (ctx) => {

--- a/packages/core/src/tasks/runner.ts
+++ b/packages/core/src/tasks/runner.ts
@@ -77,7 +77,12 @@ export async function run(ctx: PubmContext): Promise<void> {
         createBuildTask(hasPrepare, !!ctx.options.skipBuild),
         createVersionTask(hasPrepare, dryRun),
         ...createPublishTasks(hasPublish, dryRun, !!ctx.options.skipPublish),
-        ...createDryRunTasks(dryRun, mode, hasPrepare, !!ctx.options.skipDryRun),
+        ...createDryRunTasks(
+          dryRun,
+          mode,
+          hasPrepare,
+          !!ctx.options.skipDryRun,
+        ),
         createPushTask(hasPrepare, dryRun),
         createReleaseTask(
           hasPublish,

--- a/packages/core/src/tasks/runner.ts
+++ b/packages/core/src/tasks/runner.ts
@@ -77,7 +77,7 @@ export async function run(ctx: PubmContext): Promise<void> {
         createBuildTask(hasPrepare, !!ctx.options.skipBuild),
         createVersionTask(hasPrepare, dryRun),
         ...createPublishTasks(hasPublish, dryRun, !!ctx.options.skipPublish),
-        ...createDryRunTasks(dryRun, mode, hasPrepare),
+        ...createDryRunTasks(dryRun, mode, hasPrepare, !!ctx.options.skipDryRun),
         createPushTask(hasPrepare, dryRun),
         createReleaseTask(
           hasPublish,

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -60,6 +60,11 @@ export interface Options {
    */
   skipBuild?: boolean;
   /**
+   * @description Skip dry-run validation during prepare phase
+   * @default false
+   */
+  skipDryRun?: boolean;
+  /**
    * @description Skip publishing task
    * @default false
    */

--- a/packages/core/tests/unit/tasks/dry-run-publish.test.ts
+++ b/packages/core/tests/unit/tasks/dry-run-publish.test.ts
@@ -310,6 +310,57 @@ describe("createCratesDryRunPublishTask", () => {
     expect(mockTask.title).toContain("my-lib");
   });
 
+  it("reactive fallback: skips when dry-run fails with version mismatch for sibling", async () => {
+    const mockDryRun = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'failed to select a version for the requirement `my-lib = "^0.3.0"`\n' +
+            "candidate versions found which didn't match: 0.2.0\n" +
+            "location searched: crates.io index",
+        ),
+      );
+    mockedRustEcosystem.mockImplementation(function (this: any, p: string) {
+      const name = p.includes("my-lib") ? "my-lib" : "my-cli";
+      return {
+        packageName: vi.fn().mockResolvedValue(name),
+        dependencies: vi.fn().mockResolvedValue([]),
+      } as any;
+    });
+    mockedCratesRegistry.mockImplementation((path: string) => {
+      const name = path === "packages/my-lib" ? "my-lib" : "my-cli";
+      // my-cli: new version NOT yet published (so pre-check passes and dry-run executes)
+      // my-lib: new version IS published (so proactive check passes for sibling)
+      const isVersionPublished = name === "my-lib";
+      return Promise.resolve({
+        packageName: name,
+        isPublished: vi.fn().mockResolvedValue(true),
+        isVersionPublished: vi.fn().mockResolvedValue(isVersionPublished),
+        dryRunPublish: mockDryRun,
+      } as any);
+    });
+
+    const mockTask = { output: "", title: "" };
+    const ctx = {
+      runtime: {
+        versionPlan: {
+          mode: "independent",
+          packages: new Map([
+            ["packages/my-lib", "0.3.0"],
+            ["packages/my-cli", "0.3.0"],
+          ]),
+        },
+      },
+    };
+    const task = createCratesDryRunPublishTask("packages/my-cli", [
+      "packages/my-lib",
+      "packages/my-cli",
+    ]);
+    await (task as any).task(ctx, mockTask);
+    expect(mockTask.title).toContain("skipped");
+    expect(mockTask.title).toContain("my-lib");
+  });
+
   it("throws when error is about a non-sibling missing crate", async () => {
     const mockDryRun = vi
       .fn()

--- a/packages/core/tests/unit/tasks/dry-run-publish.test.ts
+++ b/packages/core/tests/unit/tasks/dry-run-publish.test.ts
@@ -161,11 +161,61 @@ describe("createCratesDryRunPublishTask", () => {
     });
 
     const mockTask = { output: "", title: "" };
+    const ctx = {
+      runtime: {
+        versionPlan: {
+          mode: "independent",
+          packages: new Map([
+            ["packages/my-lib", "0.3.0"],
+            ["packages/my-cli", "0.3.0"],
+          ]),
+        },
+      },
+    };
     const task = createCratesDryRunPublishTask("packages/my-cli", [
       "packages/my-lib",
       "packages/my-cli",
     ]);
-    await (task as any).task({ runtime: {} }, mockTask);
+    await (task as any).task(ctx, mockTask);
+    expect(mockTask.title).toContain("skipped");
+    expect(mockTask.title).toContain("my-lib");
+  });
+
+  it("proactively skips when sibling's new version is not yet published", async () => {
+    mockedRustEcosystem.mockImplementation(function (this: any, p: string) {
+      const name = p.includes("my-lib") ? "my-lib" : "my-cli";
+      return {
+        packageName: vi.fn().mockResolvedValue(name),
+        dependencies: vi.fn().mockResolvedValue(["my-lib", "serde"]),
+      } as any;
+    });
+    mockedCratesRegistry.mockImplementation((path: string) => {
+      const name = path === "packages/my-lib" ? "my-lib" : "my-cli";
+      return Promise.resolve({
+        packageName: name,
+        isPublished: vi.fn().mockResolvedValue(true), // crate EXISTS
+        isVersionPublished: vi.fn().mockResolvedValue(false), // but new version does NOT
+        dryRunPublish: vi.fn(),
+      } as any);
+    });
+
+    const mockTask = { output: "", title: "" };
+    const ctx = {
+      runtime: {
+        versionPlan: {
+          mode: "independent",
+          packages: new Map([
+            ["packages/my-lib", "0.3.0"],
+            ["packages/my-cli", "0.3.0"],
+          ]),
+        },
+      },
+    };
+    const task = createCratesDryRunPublishTask("packages/my-cli", [
+      "packages/my-lib",
+      "packages/my-cli",
+    ]);
+    await (task as any).task(ctx, mockTask);
     expect(mockTask.title).toContain("skipped");
     expect(mockTask.title).toContain("my-lib");
   });
@@ -180,20 +230,34 @@ describe("createCratesDryRunPublishTask", () => {
     });
     mockedCratesRegistry.mockImplementation((path: string) => {
       const name = path === "packages/my-lib" ? "my-lib" : "my-cli";
+      // my-cli: new version NOT yet published (so dry-run proceeds)
+      // my-lib: new version IS published (so proactive check passes for sibling)
+      const isVersionPublished = name === "my-lib";
       return Promise.resolve({
         packageName: name,
         isPublished: vi.fn().mockResolvedValue(true),
-        isVersionPublished: vi.fn().mockResolvedValue(false),
+        isVersionPublished: vi.fn().mockResolvedValue(isVersionPublished),
         dryRunPublish: mockDryRun,
       } as any);
     });
 
-    const mockTask = { output: "" };
+    const mockTask = { output: "", skip: vi.fn() };
+    const ctx = {
+      runtime: {
+        versionPlan: {
+          mode: "independent",
+          packages: new Map([
+            ["packages/my-lib", "0.3.0"],
+            ["packages/my-cli", "0.3.0"],
+          ]),
+        },
+      },
+    };
     const task = createCratesDryRunPublishTask("packages/my-cli", [
       "packages/my-lib",
       "packages/my-cli",
     ]);
-    await (task as any).task({ runtime: {} }, mockTask);
+    await (task as any).task(ctx, mockTask);
     expect(mockDryRun).toHaveBeenCalledWith();
   });
 
@@ -214,20 +278,34 @@ describe("createCratesDryRunPublishTask", () => {
     });
     mockedCratesRegistry.mockImplementation((path: string) => {
       const name = path === "packages/my-lib" ? "my-lib" : "my-cli";
+      // my-cli: new version NOT yet published (so pre-check passes and dry-run executes)
+      // my-lib: new version IS published (so proactive check passes for sibling)
+      const isVersionPublished = name === "my-lib";
       return Promise.resolve({
         packageName: name,
         isPublished: vi.fn().mockResolvedValue(true),
-        isVersionPublished: vi.fn().mockResolvedValue(false),
+        isVersionPublished: vi.fn().mockResolvedValue(isVersionPublished),
         dryRunPublish: mockDryRun,
       } as any);
     });
 
     const mockTask = { output: "", title: "" };
+    const ctx = {
+      runtime: {
+        versionPlan: {
+          mode: "independent",
+          packages: new Map([
+            ["packages/my-lib", "0.3.0"],
+            ["packages/my-cli", "0.3.0"],
+          ]),
+        },
+      },
+    };
     const task = createCratesDryRunPublishTask("packages/my-cli", [
       "packages/my-lib",
       "packages/my-cli",
     ]);
-    await (task as any).task({ runtime: {} }, mockTask);
+    await (task as any).task(ctx, mockTask);
     expect(mockTask.title).toContain("skipped");
     expect(mockTask.title).toContain("my-lib");
   });

--- a/packages/core/tests/unit/tasks/phases/dry-run.test.ts
+++ b/packages/core/tests/unit/tasks/phases/dry-run.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createDryRunTasks } from "../../../../src/tasks/phases/dry-run.js";
+
+describe("createDryRunTasks", () => {
+  it("returns enabled tasks when skipDryRun is false and ci+prepare", () => {
+    const tasks = createDryRunTasks(false, "ci", true, false);
+    expect(tasks[0].enabled).toBe(true);
+  });
+
+  it("returns disabled tasks when skipDryRun is true", () => {
+    const tasks = createDryRunTasks(false, "ci", true, true);
+    expect(tasks[0].enabled).toBe(false);
+    expect(tasks[1].enabled).toBe(false);
+  });
+
+  it("returns disabled tasks when neither dryRun nor ci+prepare", () => {
+    const tasks = createDryRunTasks(false, "local", false, false);
+    expect(tasks[0].enabled).toBe(false);
+  });
+
+  it("returns enabled tasks when dryRun is true and skipDryRun is false", () => {
+    const tasks = createDryRunTasks(true, "local", false, false);
+    expect(tasks[0].enabled).toBe(true);
+  });
+
+  it("skipDryRun overrides dryRun flag", () => {
+    const tasks = createDryRunTasks(true, "local", false, true);
+    expect(tasks[0].enabled).toBe(false);
+  });
+});

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -76,6 +76,7 @@ interface CliOptions {
   contents?: string;
   registry?: string;
   saveToken: boolean;
+  dryRunValidation: boolean;
   dangerouslyAllowUnpublish?: boolean;
   createPr?: boolean;
   locale?: string;

--- a/packages/pubm/src/cli.ts
+++ b/packages/pubm/src/cli.ts
@@ -105,6 +105,7 @@ export function resolveCliOptions(
     skipReleaseDraft: !!options.skipRelease,
     skipTests: !options.tests,
     skipBuild: !options.build,
+    skipDryRun: !options.dryRunValidation,
     skipPrerequisitesCheck: !options.preCheck,
     skipConditionsCheck: !options.conditionCheck,
     tag: options.tag,
@@ -169,6 +170,7 @@ export function createProgram(): Command {
     .option("--no-tests", t("cli.option.noTests"))
     .option("--no-build", t("cli.option.noBuild"))
     .option("--no-publish", t("cli.option.noPublish"))
+    .option("--no-dry-run-validation", t("cli.option.noDryRunValidation"))
     .option("--skip-release", t("cli.option.skipRelease"))
     .option("-t, --tag <name>", t("cli.option.tag"), "latest")
     .option("-c, --contents <path>", t("cli.option.contents"))
@@ -186,7 +188,11 @@ export function createProgram(): Command {
       ): Promise<void> => {
         console.clear();
 
-        const cliOptions = resolveOptions(resolveCliOptions(options));
+        const rawCliOpts = resolveCliOptions(options);
+        if (!rawCliOpts.skipDryRun && resolvedConfig.skipDryRun) {
+          rawCliOpts.skipDryRun = true;
+        }
+        const cliOptions = resolveOptions(rawCliOpts);
         validateOptions(cliOptions);
 
         if (!isCI && process.stderr.isTTY) {

--- a/website/src/content/docs/de/guides/configuration.mdx
+++ b/website/src/content/docs/de/guides/configuration.mdx
@@ -149,7 +149,7 @@ Ob unterstützte Registry-Tokens für spätere lokale Laeufe gespeichert werden 
 - Type: `boolean`
 - Default: `false`
 
-Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+Überspringt die Dry-Run-Validierung während der Prepare-Phase. Nützlich, wenn Workspace-Crates interne Abhängigkeiten haben, deren neue Versionen noch nicht auf crates.io veröffentlicht sind. Kann auch über das CLI-Flag `--no-dry-run-validation` gesetzt werden.
 
 ### `releaseDraft`
 

--- a/website/src/content/docs/de/guides/configuration.mdx
+++ b/website/src/content/docs/de/guides/configuration.mdx
@@ -144,6 +144,13 @@ Verzeichnis, in das vor dem Start der Release-Pipeline gewechselt wird.
 
 Ob unterstützte Registry-Tokens für spätere lokale Laeufe gespeichert werden sollen.
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - Typ: `boolean`

--- a/website/src/content/docs/de/reference/cli.mdx
+++ b/website/src/content/docs/de/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | Überspringt den Test-Schritt. |
 | `--no-build` | Überspringt den Build-Schritt. |
 | `--no-publish` | Laeuft bis zum Publish, veröffentlicht Artefakte aber nicht wirklich. |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | Überspringt die GitHub-Release-Erstellung. |
 
 ## Ausführungsmodi

--- a/website/src/content/docs/de/reference/cli.mdx
+++ b/website/src/content/docs/de/reference/cli.mdx
@@ -105,7 +105,7 @@ pubm --tag beta
 | `--no-tests` | Überspringt den Test-Schritt. |
 | `--no-build` | Überspringt den Build-Schritt. |
 | `--no-publish` | Laeuft bis zum Publish, veröffentlicht Artefakte aber nicht wirklich. |
-| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
+| `--no-dry-run-validation` | Überspringt die Dry-Run-Validierung während der Prepare-Phase. Nützlich, wenn Workspace-Crates interne Abhängigkeiten haben, deren neue Versionen noch nicht veröffentlicht sind. |
 | `--skip-release` | Überspringt die GitHub-Release-Erstellung. |
 
 ## Ausführungsmodi

--- a/website/src/content/docs/es/guides/configuration.mdx
+++ b/website/src/content/docs/es/guides/configuration.mdx
@@ -149,7 +149,7 @@ Indica si los tokens de registry compatibles deben guardarse para reutilizarlos 
 - Type: `boolean`
 - Default: `false`
 
-Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+Omite la validación de dry-run durante la fase de preparación. Útil cuando los crates del workspace tienen dependencias internas cuyas nuevas versiones aún no se han publicado en crates.io. También se puede configurar mediante el flag CLI `--no-dry-run-validation`.
 
 ### `releaseDraft`
 

--- a/website/src/content/docs/es/guides/configuration.mdx
+++ b/website/src/content/docs/es/guides/configuration.mdx
@@ -144,6 +144,13 @@ Directorio al que se hace `chdir` antes de ejecutar el pipeline de release.
 
 Indica si los tokens de registry compatibles deben guardarse para reutilizarlos en máquinas locales.
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - Tipo: `boolean`

--- a/website/src/content/docs/es/reference/cli.mdx
+++ b/website/src/content/docs/es/reference/cli.mdx
@@ -105,7 +105,7 @@ pubm --tag beta
 | `--no-tests` | Omite el paso de tests. |
 | `--no-build` | Omite el paso de build. |
 | `--no-publish` | Ejecuta el pipeline hasta publish, pero no publica artefactos realmente. |
-| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
+| `--no-dry-run-validation` | Omite la validación de dry-run durante la fase de preparación. Útil cuando los crates del workspace tienen dependencias internas cuyas nuevas versiones aún no se han publicado. |
 | `--skip-release` | Omite la creación de GitHub Release. |
 
 ## Modos de ejecución

--- a/website/src/content/docs/es/reference/cli.mdx
+++ b/website/src/content/docs/es/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | Omite el paso de tests. |
 | `--no-build` | Omite el paso de build. |
 | `--no-publish` | Ejecuta el pipeline hasta publish, pero no publica artefactos realmente. |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | Omite la creación de GitHub Release. |
 
 ## Modos de ejecución

--- a/website/src/content/docs/fr/guides/configuration.mdx
+++ b/website/src/content/docs/fr/guides/configuration.mdx
@@ -144,6 +144,13 @@ Répertoire dans lequel faire `chdir` avant d'exécuter le pipeline de release.
 
 Indique si les tokens de registry pris en charge doivent être stockés pour réutilisation sur les machines locales.
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - Type : `boolean`

--- a/website/src/content/docs/fr/guides/configuration.mdx
+++ b/website/src/content/docs/fr/guides/configuration.mdx
@@ -149,7 +149,7 @@ Indique si les tokens de registry pris en charge doivent être stockés pour ré
 - Type: `boolean`
 - Default: `false`
 
-Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+Ignorer la validation en dry-run pendant la phase de préparation. Utile lorsque des crates du workspace ont des dépendances internes dont les nouvelles versions ne sont pas encore publiées sur crates.io. Peut aussi être défini via le flag CLI `--no-dry-run-validation`.
 
 ### `releaseDraft`
 

--- a/website/src/content/docs/fr/reference/cli.mdx
+++ b/website/src/content/docs/fr/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | Ignorer l'étape de test. |
 | `--no-build` | Ignorer l'étape de build. |
 | `--no-publish` | Exécuter le pipeline jusqu'à la publication, sans publier réellement les artefacts. |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | Ignorer la création de GitHub Release. |
 
 ## Modes d'exécution

--- a/website/src/content/docs/fr/reference/cli.mdx
+++ b/website/src/content/docs/fr/reference/cli.mdx
@@ -105,7 +105,7 @@ pubm --tag beta
 | `--no-tests` | Ignorer l'étape de test. |
 | `--no-build` | Ignorer l'étape de build. |
 | `--no-publish` | Exécuter le pipeline jusqu'à la publication, sans publier réellement les artefacts. |
-| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
+| `--no-dry-run-validation` | Ignorer la validation en dry-run pendant la phase de préparation. Utile lorsque des crates du workspace ont des dépendances internes dont les nouvelles versions ne sont pas encore publiées. |
 | `--skip-release` | Ignorer la création de GitHub Release. |
 
 ## Modes d'exécution

--- a/website/src/content/docs/guides/configuration.mdx
+++ b/website/src/content/docs/guides/configuration.mdx
@@ -144,6 +144,13 @@ Directory to `chdir` into before running the release pipeline.
 
 Whether supported registry tokens should be stored for reuse on local machines.
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - Type: `boolean`

--- a/website/src/content/docs/ko/guides/configuration.mdx
+++ b/website/src/content/docs/ko/guides/configuration.mdx
@@ -149,7 +149,7 @@ publish 실행의 기본 dist-tag입니다.
 - Type: `boolean`
 - Default: `false`
 
-Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+prepare 단계에서 dry-run 검증을 생략합니다. workspace crate의 내부 의존성 새 버전이 아직 crates.io에 배포되지 않은 경우 유용합니다. `--no-dry-run-validation` CLI 플래그로도 설정할 수 있습니다.
 
 ### `releaseDraft`
 

--- a/website/src/content/docs/ko/guides/configuration.mdx
+++ b/website/src/content/docs/ko/guides/configuration.mdx
@@ -144,6 +144,13 @@ publish 실행의 기본 dist-tag입니다.
 
 지원되는 레지스트리 토큰을 로컬 머신에서 재사용하도록 저장할지 여부입니다.
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - 타입: `boolean`

--- a/website/src/content/docs/ko/reference/cli.mdx
+++ b/website/src/content/docs/ko/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | 테스트 단계를 생략합니다. |
 | `--no-build` | 빌드 단계를 생략합니다. |
 | `--no-publish` | publish 직전까지 실행하되, 실제로는 artifacts를 publish하지 않습니다. |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | GitHub Release 생성을 생략합니다. |
 
 ## 실행 모드

--- a/website/src/content/docs/ko/reference/cli.mdx
+++ b/website/src/content/docs/ko/reference/cli.mdx
@@ -105,7 +105,7 @@ pubm --tag beta
 | `--no-tests` | 테스트 단계를 생략합니다. |
 | `--no-build` | 빌드 단계를 생략합니다. |
 | `--no-publish` | publish 직전까지 실행하되, 실제로는 artifacts를 publish하지 않습니다. |
-| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
+| `--no-dry-run-validation` | prepare 단계에서 dry-run 검증을 생략합니다. workspace crate의 내부 의존성이 아직 배포되지 않은 경우 유용합니다. |
 | `--skip-release` | GitHub Release 생성을 생략합니다. |
 
 ## 실행 모드

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | Skip the test step. |
 | `--no-build` | Skip the build step. |
 | `--no-publish` | Run the pipeline up to publish, but do not actually publish artifacts. |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | Skip GitHub Release creation. |
 
 ## Execution modes

--- a/website/src/content/docs/zh-cn/guides/configuration.mdx
+++ b/website/src/content/docs/zh-cn/guides/configuration.mdx
@@ -149,7 +149,7 @@ npm 还适用两条额外规则：
 - Type: `boolean`
 - Default: `false`
 
-Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+跳过准备阶段的 dry-run 验证。当 workspace crate 的内部依赖的新版本尚未发布到 crates.io 时很有用。也可以通过 `--no-dry-run-validation` CLI 标志设置。
 
 ### `releaseDraft`
 

--- a/website/src/content/docs/zh-cn/guides/configuration.mdx
+++ b/website/src/content/docs/zh-cn/guides/configuration.mdx
@@ -144,6 +144,13 @@ npm 还适用两条额外规则：
 
 是否将受支持 registry 的 token 保存起来，供本地机器后续复用。
 
+### `skipDryRun`
+
+- Type: `boolean`
+- Default: `false`
+
+Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published on crates.io. Can also be set via the `--no-dry-run-validation` CLI flag.
+
 ### `releaseDraft`
 
 - 类型：`boolean`

--- a/website/src/content/docs/zh-cn/reference/cli.mdx
+++ b/website/src/content/docs/zh-cn/reference/cli.mdx
@@ -105,7 +105,7 @@ pubm --tag beta
 | `--no-tests` | 跳过测试步骤。 |
 | `--no-build` | 跳过构建步骤。 |
 | `--no-publish` | 运行到 publish 之前，但不真正发布构件。 |
-| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
+| `--no-dry-run-validation` | 跳过准备阶段的 dry-run 验证。当 workspace crate 的内部依赖的新版本尚未发布时很有用。 |
 | `--skip-release` | 跳过 GitHub Release 创建。 |
 
 ## 执行模式

--- a/website/src/content/docs/zh-cn/reference/cli.mdx
+++ b/website/src/content/docs/zh-cn/reference/cli.mdx
@@ -105,6 +105,7 @@ pubm --tag beta
 | `--no-tests` | 跳过测试步骤。 |
 | `--no-build` | 跳过构建步骤。 |
 | `--no-publish` | 运行到 publish 之前，但不真正发布构件。 |
+| `--no-dry-run-validation` | Skip dry-run validation during the prepare phase. Useful when workspace crates have internal dependencies whose new versions aren't yet published. |
 | `--skip-release` | 跳过 GitHub Release 创建。 |
 
 ## 执行模式


### PR DESCRIPTION
## Summary

Closes #18

- **Bug fix**: `findUnpublishedSiblingDeps()` now uses `isVersionPublished(newVersion)` instead of `isPublished()`, correctly detecting when a sibling crate exists but its new version hasn't been published yet
- **Bug fix**: Reactive fallback now catches `failed to select a version for the requirement` errors (version mismatch), not just `no matching package named` errors
- **New feature**: `--no-dry-run-validation` CLI flag and `skipDryRun` config option to skip dry-run validation entirely during the prepare phase

## Test plan

- [x] New test: proactive skip when sibling's new version is not yet published
- [x] New test: reactive fallback for version mismatch error pattern
- [x] New test: `skipDryRun` enabled condition in `createDryRunTasks`
- [x] Updated existing tests to include `versionPlan` in context
- [x] All 2166+ tests passing across 17 packages
- [x] Typecheck passing
- [x] Documentation updated for all 6 locales