### PR TITLE
docs(site): add llms.txt endpoints

### DIFF
--- a/docs/plans/20260429-2251-llms-txt.plan.md
+++ b/docs/plans/20260429-2251-llms-txt.plan.md
@@ -1,0 +1,220 @@
+---
+title: "Adopt llms.txt"
+status: "draft"
+created: "2026-04-29 22:51 KST"
+spec: "20260429-2251-llms-txt.spec.md"
+plan_id: "20260429-2251-llms-txt"
+---
+
+# Plan: Adopt llms.txt
+
+## Source Spec
+
+- Spec file: `docs/plans/20260429-2251-llms-txt.spec.md`
+- Goals covered:
+  - Publish concise and full English LLM-friendly docs files for the pubm docs site.
+  - Keep URLs correct for the `/pubm` GitHub Pages base path.
+  - Preserve Part B as a follow-up design using current `releaseAssets` and asset hooks as the starting point.
+- Non-goals preserved:
+  - No locale-specific `llms.txt` or `llms-full.txt` files in this pass.
+  - No new `@pubm/plugin-llms-txt` package.
+  - No new core config field, CLI command, SDK API, or release pipeline behavior.
+  - No generated `.md` siblings for every docs page.
+
+## Implementation Strategy
+
+Implement Part A English-only. Add static Astro endpoint routes that generate text responses at build time from the existing Starlight docs collection. Put content selection, URL generation, and rendering in one shared website helper so the two route files stay thin.
+
+Use a curated canonical docs order for the concise index, but source titles, descriptions, and raw Markdown body from `getCollection("docs")`. If a curated English slug is missing, fail the build with a clear error instead of silently producing incomplete context.
+
+## File And Module Map
+
+- Create:
+  - `website/src/llms.ts` - shared English docs loading, URL, and text rendering helpers.
+  - `website/src/pages/llms.txt.ts` - root English concise endpoint.
+  - `website/src/pages/llms-full.txt.ts` - root English full endpoint.
+- Modify:
+  - None required for first implementation.
+- Delete:
+  - None.
+- Leave unchanged:
+  - `packages/core/src/**` and `packages/plugins/**`, because Part B is not in first scope.
+  - `website/public/**`, because generated routes are preferable to checked-in static text files.
+  - `.pubm/changesets/**`, because this docs-site implementation does not change a published package.
+
+## Task Breakdown
+
+### Phase 1: Add Shared Generation Helper
+
+#### Task 1: Create the docs selection helper
+
+**Files**
+- Create: `website/src/llms.ts`
+
+- [ ] Define site constants:
+  - `SITE_ORIGIN = "https://syi0808.github.io"`
+  - `SITE_BASE = "/pubm"`
+- [ ] Define a curated docs map in canonical slug order:
+  - `guides/quick-start`
+  - `guides/configuration`
+  - `guides/monorepo`
+  - `guides/changesets`
+  - `guides/ci-cd`
+  - `guides/coding-agents`
+  - `guides/release-assets`
+  - `guides/asset-pipeline-hooks`
+  - `guides/troubleshooting`
+  - `reference/cli`
+  - `reference/sdk`
+  - `reference/plugins`
+  - `reference/official-plugins`
+  - `reference/platform-detection`
+- [ ] Import `getCollection` from `astro:content`.
+- [ ] Load English docs only by ignoring entries whose `id` starts with known locale prefixes: `ko/`, `zh-cn/`, `fr/`, `de/`, or `es/`.
+- [ ] Build a `Map<string, LlmsDoc>` keyed by slug, keeping `title`, `description`, `body`, and public URL.
+- [ ] Preserve curated order and throw `new Error("Missing English docs entry for ${slug}")` for missing pages.
+
+#### Task 2: Add URL and response renderers
+
+**Files**
+- Create: `website/src/llms.ts`
+
+- [ ] Add `docUrl(slug: string): string` that returns `https://syi0808.github.io/pubm/${slug}/`.
+- [ ] Add `renderLlmsTxt(): Promise<string>`.
+  - Start with `# pubm`.
+  - Add a blockquote summary: "Publish to npm, jsr, crates.io, and private registries in one step. Automatic rollback if anything fails."
+  - Add one short note explaining pubm's role as a multi-registry release CLI.
+  - Render H2 sections for Getting Started, Guides, Reference, and Optional.
+  - Use `- [${doc.title}](${doc.url}): ${doc.description}` for each item.
+  - In Optional, link to `https://syi0808.github.io/pubm/llms-full.txt`.
+  - End with a single trailing newline.
+- [ ] Add `renderLlmsFullTxt(): Promise<string>`.
+  - Start with `# pubm Documentation`.
+  - Add a blockquote identifying it as full Markdown context for pubm docs.
+  - Add a table of contents with links to public docs URLs.
+  - For each doc in curated order, render `## ${doc.title}`, `Source: ${doc.url}`, `Description: ${doc.description}`, and raw `doc.body.trim()`.
+  - Separate documents with `---`.
+  - End with a single trailing newline.
+- [ ] Add `textResponse(body: string): Response` with `Content-Type: text/plain; charset=utf-8`.
+
+### Phase 2: Add Static Endpoint Routes
+
+#### Task 3: Add root English routes
+
+**Files**
+- Create: `website/src/pages/llms.txt.ts`
+- Create: `website/src/pages/llms-full.txt.ts`
+
+- [ ] Implement `website/src/pages/llms.txt.ts`.
+
+```ts
+import { renderLlmsTxt, textResponse } from "../llms";
+
+export async function GET() {
+  return textResponse(await renderLlmsTxt());
+}
+```
+
+- [ ] Implement `website/src/pages/llms-full.txt.ts`.
+
+```ts
+import { renderLlmsFullTxt, textResponse } from "../llms";
+
+export async function GET() {
+  return textResponse(await renderLlmsFullTxt());
+}
+```
+
+### Phase 3: Verify Build Output
+
+#### Task 4: Build the site and inspect generated files
+
+**Files**
+- Test: generated files under `website/dist/`
+
+- [ ] Run the site build.
+  - Command: `pnpm build` from `website/`
+  - Expected: exit code `0`; Astro writes `dist`.
+- [ ] Verify root text files exist.
+  - Command: `find website/dist -maxdepth 2 -name 'llms*.txt' | sort`
+  - Expected output includes `website/dist/llms.txt` and `website/dist/llms-full.txt`.
+- [ ] Verify root links include the deployed base path.
+  - Command: `rg -n "https://syi0808.github.io/pubm/guides/quick-start/|https://syi0808.github.io/pubm/reference/cli/" website/dist/llms.txt`
+  - Expected: both URLs are present.
+- [ ] Verify full-file content contains guide and reference prose.
+  - Command: `rg -n "^## Quick Start|^## CLI Reference|^## Asset Pipeline Hooks" website/dist/llms-full.txt`
+  - Expected: all three headings are present.
+
+### Phase 4: Review Scope Boundaries
+
+#### Task 5: Re-read changed files against the issue
+
+**Files**
+- Review: `website/src/llms.ts`
+- Review: `website/src/pages/llms.txt.ts`
+- Review: `website/src/pages/llms-full.txt.ts`
+- Review: `docs/plans/20260429-2251-llms-txt.spec.md`
+- Review: `docs/plans/20260429-2251-llms-txt.plan.md`
+
+- [ ] Confirm no `packages/core` or `packages/plugins` files changed.
+  - Command: `git diff --name-only`
+  - Expected: only website endpoint/helper files and planning docs appear.
+- [ ] Confirm concise file follows the `llms.txt` structure.
+  - Check: H1 appears first.
+  - Check: summary appears as a blockquote.
+  - Check: link lists live under H2 headings.
+  - Check: Optional section only contains skippable full-context link.
+- [ ] Confirm no package changeset is needed for this implementation.
+  - Reason: first scope changes only the docs site and planning docs, not a published package or package behavior.
+
+## Interfaces, Data Flow, And State
+
+- Astro calls endpoint `GET` during static build.
+- Endpoint calls the shared renderer.
+- Renderer calls `getCollection("docs")`.
+- Helper filters English entries, orders docs with the curated groups, and renders plain text.
+- Astro writes generated text files to `website/dist`.
+- Runtime state: none. All files are static build output.
+
+## Edge Cases And Failure Modes
+
+- Missing English doc: build should fail with a clear `Missing English docs entry for ${slug}` error.
+- Base path omission: URL builders must include `/pubm` in every public link.
+- Content collection body shape: if `entry.body` is unavailable in this Starlight loader, replace only body retrieval with a source-file reader that uses `node:path` and `node:fs` and keeps the same renderer contract.
+- Full context growth: keep explicit ordering so new docs are added intentionally.
+
+## Test And Verification Matrix
+
+- Requirement: root English files exist.
+  - Test or command: `test -f website/dist/llms.txt && test -f website/dist/llms-full.txt`
+  - Expected result: exit code `0`.
+- Requirement: concise file follows `llms.txt` shape.
+  - Test or command: `sed -n '1,80p' website/dist/llms.txt`
+  - Expected result: H1, blockquote summary, explanatory prose, H2 sections, and Markdown link lists.
+- Requirement: links include `/pubm`.
+  - Test or command: `rg -n "https://syi0808.github.io/pubm/" website/dist/llms.txt`
+  - Expected result: matches in root file.
+- Requirement: full file includes guide and reference docs.
+  - Test or command: `rg -n "^## Quick Start|^## CLI Reference|^## Platform Detection" website/dist/llms-full.txt`
+  - Expected result: all headings present.
+- Requirement: no core behavior changed.
+  - Test or command: `git diff --name-only`
+  - Expected result: no files under `packages/core/` or `packages/plugins/`.
+
+## Rollout And Review
+
+- Rollout is automatic through the existing Deploy Site workflow after the branch is merged and the Release workflow succeeds, or through manual `workflow_dispatch`.
+- Review focus:
+  - Correctness of generated URLs under GitHub Pages base path.
+  - Completeness of English docs ordering.
+  - Quality and brevity of concise `llms.txt` descriptions.
+  - `llms-full.txt` readability with code fences and headings preserved.
+- Rollback:
+  - Revert the three website files if the routes cause build or deployment problems.
+  - Planning docs can remain or be amended because they are not deployed routes.
+
+## Assumptions
+
+- First implementation follows the English-only Part A scope.
+- Astro static endpoints can use `getCollection("docs")` at build time.
+- No website-specific test runner exists, so `pnpm build` plus output inspection is the meaningful verification path.

--- a/docs/plans/20260429-2251-llms-txt.spec.md
+++ b/docs/plans/20260429-2251-llms-txt.spec.md
@@ -1,0 +1,107 @@
+---
+title: "Adopt llms.txt"
+status: "draft"
+created: "2026-04-29 22:51 KST"
+spec_id: "20260429-2251-llms-txt"
+related_plan: "20260429-2251-llms-txt.plan.md"
+---
+
+# Spec: Adopt llms.txt
+
+## Summary
+
+Issue #28 asks pubm to adopt `llms.txt` in two related ways: first for the pubm documentation site, and second as a publisher capability for users who want to ship their own `llms.txt` files during release. The first implementation will cover only the pubm docs site and will publish English root files. Locale-specific variants and product-level publishing support remain out of scope for this pass.
+
+The docs site should expose a concise `llms.txt` index and a fuller `llms-full.txt` prose dump for LLMs and coding agents. Keeping the first version English-only reduces implementation and maintenance cost while still giving agents a stable entry point.
+
+## Goals
+
+- Publish a concise English `llms.txt` for the pubm docs site with project context and curated links to the most important docs pages.
+- Publish an English `llms-full.txt` with flattened Markdown content from the English guides and reference docs.
+- Keep generated URLs correct for the GitHub Pages project base path `/pubm`.
+- Leave a clear follow-up path for user-project publishing through existing `releaseAssets` and asset pipeline hooks, without adding a new plugin or core API in the first implementation.
+
+## Non-Goals
+
+- Do not generate locale-specific `llms.txt` or `llms-full.txt` files in this pass.
+- Do not create `@pubm/plugin-llms-txt` in the first implementation.
+- Do not add a new core `llmsTxt` configuration field or CLI command in the first implementation.
+- Do not change package publishing behavior, registry behavior, versioning, rollback, or GitHub Release upload semantics.
+- Do not generate Markdown siblings for every HTML docs page with `.md` URL suffixes.
+- Do not include generated plugin bundle files from `website/public/plugins/` in `llms-full.txt`.
+
+## Current State
+
+- GitHub issue #28 is open as "Adopt and support llms.txt" and has the `enhancement` label.
+- The issue splits the work into Part A for `website/` and Part B for pubm as a publisher. It explicitly names shipping Part A first as a possible first-release scope.
+- The website is an Astro 6 and Starlight site under `website/`, built by `pnpm build` and deployed from `website/dist` by `.github/workflows/deploy-site.yml`.
+- `website/astro.config.mjs` sets `site: "https://syi0808.github.io"` and `base: "/pubm"`.
+- English Starlight docs live under `website/src/content/docs/`; localized docs are nested under locale directories and are not needed for this first implementation.
+- The docs sidebar is currently declared inline in `website/astro.config.mjs`. The sidebar covers Getting Started, Guides, and Reference sections.
+- The docs collection uses `docsLoader()` and `docsSchema()` in `website/src/content.config.ts`.
+- Existing static public files include `website/public/robots.txt` and plugin bundle files, but no `llms.txt` or `llms-full.txt`.
+- pubm already has `releaseAssets` config, asset preparation, GitHub Release uploads, and plugin hooks including `afterBuild`, `resolveAssets`, `generateChecksums`, `uploadAssets`, and `afterRelease`.
+- The `llms.txt` proposal expects Markdown at `/llms.txt`; the only required section is an H1, with optional blockquote summary, explanatory text, and H2-delimited link lists.
+
+## Audience And Use Cases
+
+- Coding agents that need a compact English entry point for pubm docs before editing a user's release configuration.
+- LLM search and retrieval systems that can discover important pubm docs from a stable plain-text route.
+- Maintainers who want the pubm docs site to model the same LLM-friendly publishing practice that pubm may help user projects automate in future work.
+
+## Requirements
+
+- The docs site must serve English `llms.txt` and `llms-full.txt` at the site root once deployed under the `/pubm` base path.
+- The concise file must use valid Markdown in the `llms.txt` structure: H1 project name, short blockquote summary, optional notes, H2 sections, and Markdown link list items with useful descriptions.
+- The concise file must prioritize Quick Start, Configuration, CI/CD, Changesets, Monorepo, Coding Agent Integration, Release Assets, Asset Pipeline Hooks, CLI Reference, SDK Reference, Plugins API, Official Plugins, and Platform Detection.
+- The full file must include flattened Markdown for all English guides and reference pages in the curated order, preserving headings and code fences well enough for model context use.
+- Generation should derive titles, descriptions, and body text from the existing Starlight content collection where practical.
+- Output should be deterministic so builds do not churn.
+- Generated URLs must be absolute or otherwise unambiguous and must include `/pubm` in deployed links.
+
+## Interfaces And Contracts
+
+- Public web routes affected:
+  - `/pubm/llms.txt`
+  - `/pubm/llms-full.txt`
+- Site build interface: `cd website && pnpm build` must generate the text files into `website/dist`.
+- Content interface: English docs frontmatter `title` and `description` remain the source for link labels and descriptions where possible.
+- No public pubm CLI, SDK, config, plugin, or package API changes are part of this first implementation.
+
+## Constraints
+
+- Astro endpoint routes must work in the existing static build and GitHub Pages deployment model.
+- Links must respect `base: "/pubm"` and not assume domain-root hosting.
+- The implementation should use existing Astro content APIs or structured metadata where practical instead of bespoke parsing.
+- The first implementation should keep core package coverage unaffected by avoiding package code changes.
+- If future work adds locale files, package features, or an official plugin, it must follow the repository's package tests, coverage thresholds, documentation update rules, and changeset workflow.
+
+## Acceptance Criteria
+
+- `cd website && pnpm build` succeeds.
+- The build output contains `dist/llms.txt` and `dist/llms-full.txt`.
+- The English concise file starts with `# pubm` and includes Markdown links to the prioritized guides and reference pages.
+- The full file includes content from every English guide and reference page in the curated order and excludes `website/public/plugins/`.
+- Generated links include the deployed `/pubm` base path.
+- No core package public API or release pipeline behavior changes are introduced by the first implementation.
+
+## Risks
+
+- Astro/Starlight content collection fields may not expose raw MDX content exactly as expected, which could require a small fallback reader for source files.
+- Hard-coded route content can drift from sidebar or docs frontmatter if the docs structure changes.
+- Generated full files may become very large as docs grow, so ordering and exclusion rules must stay explicit.
+- GitHub Pages base-path behavior must be verified from build output paths and generated links.
+
+## Assumptions
+
+- First release scope is English-only Part A: docs-site `llms.txt` and `llms-full.txt`.
+- Part B remains a follow-up design that can start from current `releaseAssets` and asset pipeline hooks.
+- Absolute links using `https://syi0808.github.io/pubm/...` are acceptable for generated files.
+- The existing English docs frontmatter is adequate for concise link descriptions.
+- `llms-full.txt` includes Starlight guide and reference docs only, not landing page copy.
+- Planning-only documents do not require a pubm changeset.
+
+## Open Questions
+
+- What should the dedicated Part B delivery shape be if pubm adds first-class support: official plugin, built-in config, or documentation-only pattern?
+- If Part B becomes an official plugin, should its source input be docs-directory based, README based, or declarative config based?

--- a/website/src/llms.ts
+++ b/website/src/llms.ts
@@ -1,0 +1,164 @@
+import { getCollection } from "astro:content";
+
+const SITE_ORIGIN = "https://syi0808.github.io";
+const SITE_BASE = "/pubm";
+
+const LOCALE_PREFIXES = ["ko/", "zh-cn/", "fr/", "de/", "es/"] as const;
+
+const DOC_GROUPS = [
+  {
+    title: "Getting Started",
+    slugs: ["guides/quick-start", "guides/configuration"],
+  },
+  {
+    title: "Guides",
+    slugs: [
+      "guides/monorepo",
+      "guides/changesets",
+      "guides/ci-cd",
+      "guides/coding-agents",
+      "guides/release-assets",
+      "guides/asset-pipeline-hooks",
+      "guides/troubleshooting",
+    ],
+  },
+  {
+    title: "Reference",
+    slugs: [
+      "reference/cli",
+      "reference/sdk",
+      "reference/plugins",
+      "reference/official-plugins",
+      "reference/platform-detection",
+    ],
+  },
+] as const;
+
+interface LlmsDoc {
+  slug: string;
+  title: string;
+  description: string;
+  body: string;
+  url: string;
+}
+
+function normalizeEnglishSlug(id: string): string | null {
+  if (LOCALE_PREFIXES.some((prefix) => id.startsWith(prefix))) {
+    return null;
+  }
+
+  return id.replace(/\.(md|mdx)$/, "");
+}
+
+function docUrl(slug: string): string {
+  return `${SITE_ORIGIN}${SITE_BASE}/${slug}/`;
+}
+
+async function loadEnglishDocs(): Promise<Map<string, LlmsDoc>> {
+  const entries = await getCollection("docs");
+  const docs = new Map<string, LlmsDoc>();
+
+  for (const entry of entries) {
+    const slug = normalizeEnglishSlug(entry.id);
+    if (!slug) continue;
+
+    docs.set(slug, {
+      slug,
+      title: entry.data.title,
+      description: entry.data.description ?? "",
+      body: entry.body.trim(),
+      url: docUrl(slug),
+    });
+  }
+
+  return docs;
+}
+
+async function orderedDocs(): Promise<
+  Array<{ title: string; docs: LlmsDoc[] }>
+> {
+  const docsBySlug = await loadEnglishDocs();
+
+  return DOC_GROUPS.map((group) => ({
+    title: group.title,
+    docs: group.slugs.map((slug) => {
+      const doc = docsBySlug.get(slug);
+      if (!doc) {
+        throw new Error(`Missing English docs entry for ${slug}`);
+      }
+      return doc;
+    }),
+  }));
+}
+
+export async function renderLlmsTxt(): Promise<string> {
+  const groups = await orderedDocs();
+  const lines = [
+    "# pubm",
+    "",
+    "> Publish to npm, jsr, crates.io, and private registries in one step. Automatic rollback if anything fails.",
+    "",
+    "pubm is a release orchestration CLI for projects that publish packages across multiple registries, packages, and ecosystems.",
+    "",
+  ];
+
+  for (const group of groups) {
+    lines.push(`## ${group.title}`, "");
+    for (const doc of group.docs) {
+      lines.push(`- [${doc.title}](${doc.url}): ${doc.description}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "## Optional",
+    "",
+    `- [Full documentation context](${SITE_ORIGIN}${SITE_BASE}/llms-full.txt): Flattened Markdown content for all English guides and reference docs.`,
+    "",
+  );
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export async function renderLlmsFullTxt(): Promise<string> {
+  const groups = await orderedDocs();
+  const docs = groups.flatMap((group) => group.docs);
+  const lines = [
+    "# pubm Documentation",
+    "",
+    "> Full Markdown context for pubm's English guides and reference docs.",
+    "",
+    "## Contents",
+    "",
+  ];
+
+  for (const doc of docs) {
+    lines.push(`- [${doc.title}](${doc.url}): ${doc.description}`);
+  }
+
+  for (const doc of docs) {
+    lines.push(
+      "",
+      "---",
+      "",
+      `## ${doc.title}`,
+      "",
+      `Source: ${doc.url}`,
+      "",
+      `Description: ${doc.description}`,
+      "",
+      doc.body,
+    );
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function textResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/website/src/pages/llms-full.txt.ts
+++ b/website/src/pages/llms-full.txt.ts
@@ -1,0 +1,5 @@
+import { renderLlmsFullTxt, textResponse } from "../llms";
+
+export async function GET() {
+  return textResponse(await renderLlmsFullTxt());
+}

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,0 +1,5 @@
+import { renderLlmsTxt, textResponse } from "../llms";
+
+export async function GET() {
+  return textResponse(await renderLlmsTxt());
+}


### PR DESCRIPTION
## Summary

Refs #28

- Add Astro text endpoints for the docs site root `/llms.txt` and `/llms-full.txt`.
- Generate a concise English `llms.txt` index from curated Starlight guide/reference pages.
- Generate `llms-full.txt` as flattened English Markdown context from the same docs collection.
- Document the English-only first-pass scope and leave locale variants plus pubm publishing support for follow-up work.

## Test plan

- [x] `PATH=\"/Users/sung-yein/.nvm/versions/node/v24.5.0/bin:$PATH\" pnpm build` from `website/`
- [x] `bunx biome check website/src/llms.ts website/src/pages/llms.txt.ts website/src/pages/llms-full.txt.ts`
- [x] `find website/dist -maxdepth 2 -name 'llms*.txt' | sort` shows only `website/dist/llms.txt` and `website/dist/llms-full.txt`
- [x] `rg -n \"https://syi0808.github.io/pubm/guides/quick-start/|https://syi0808.github.io/pubm/reference/cli/\" website/dist/llms.txt`
- [x] `rg -n \"^## Quick Start|^## CLI Reference|^## Asset Pipeline Hooks\" website/dist/llms-full.txt`

## Notes

The local `website/` PATH resolved Node 18 first, which Astro 6 does not support. Verification used Node 24 explicitly by prepending the nvm Node 24 bin path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add build-time docs endpoints at `/llms.txt` and `/llms-full.txt` to provide a concise index and a full Markdown dump for LLMs and coding agents. English-only first pass; links include the `/pubm` base path.

- **New Features**
  - Generate `llms.txt` from curated English guides and reference pages with absolute links under `https://syi0808.github.io/pubm/`.
  - Generate `llms-full.txt` with a flattened Markdown dump and a simple table of contents.
  - Add `website/src/llms.ts` to load docs via Astro `getCollection`, keep a fixed order, and fail the build if a curated page is missing.

<sup>Written for commit 7658c9797199eb9d4b740311755ba65acab13f8b. Summary will update on new commits. <a href="https://cubic.dev/pr/syi0808/pubm/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

